### PR TITLE
MessageContext::get_message

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -8,10 +8,13 @@ fn main() {
     ctx.add_messages("key1 = Value 1");
     ctx.add_messages("key2 = Value 2");
 
-    let msg = ctx.get_message("key1").unwrap();
-
-    match ctx.format(&msg) {
-        Ok(v) => println!("{}", v),
-        Err(err) => println!("Couldn't retrieve: {:?}", err),
+    if let Some(msg) = ctx.get_message("key1") {
+        match ctx.format(&msg) {
+            Ok(v) => println!("Formatted value: {}", v),
+            Err(err) => println!("Formatting error: {:?}", err),
+        }
+    } else {
+        println!("Missing message: {}", "key1");
     }
+
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -8,10 +8,10 @@ fn main() {
     ctx.add_messages("key1 = Value 1");
     ctx.add_messages("key2 = Value 2");
 
-    let id = String::from("key1");
+    let msg = ctx.get_message("key1").unwrap();
 
-    match ctx.format(&id) {
-        Ok(v) => println!("Message for key {} - {}", &id, v),
-        Err(err) => println!("Couldn't retrieve the entry {:?}: {:?}", &id, err),
+    match ctx.format(&msg) {
+        Ok(v) => println!("{}", v),
+        Err(err) => println!("Couldn't retrieve: {:?}", err),
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -25,13 +25,8 @@ impl MessageContext {
 
         for entry in res.0 {
             match entry {
-                ast::Entry::Message(ast::Message { id, value, traits }) => {
-                    self.messages.insert(id.clone(),
-                                         ast::Message {
-                                             id: id,
-                                             value: value,
-                                             traits: traits,
-                                         });
+                ast::Entry::Message(msg @ ast::Message { .. }) => {
+                    self.messages.insert(msg.id.clone(), msg);
                 }
             }
         }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -39,15 +39,14 @@ impl MessageContext {
         Ok(())
     }
 
-    pub fn format(&self, id: &str) -> Result<String, ContextError> {
-        match self.entries.get(id) {
-            Some(ref value) => {
-                match resolve(self, value) {
-                    Ok(msg) => Ok(msg),
-                    Err(_) => Err(ContextError::Generic),
-                }
-            }
-            None => Err(ContextError::Generic),
+    pub fn get_message(&self, id: &str) -> Option<&ast::Value> {
+        self.entries.get(id)
+    }
+
+    pub fn format(&self, value: &ast::Value) -> Result<String, ContextError> {
+        match resolve(self, value) {
+            Ok(msg) => Ok(msg),
+            Err(_) => Err(ContextError::Generic),
         }
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -12,12 +12,12 @@ pub enum ContextError {
 }
 
 pub struct MessageContext {
-    entries: HashMap<String, ast::Entry>,
+    messages: HashMap<String, ast::Message>,
 }
 
 impl MessageContext {
     pub fn new() -> MessageContext {
-        MessageContext { entries: HashMap::new() }
+        MessageContext { messages: HashMap::new() }
     }
 
     pub fn add_messages(&mut self, source: &str) -> Result<(), ParserError> {
@@ -25,13 +25,13 @@ impl MessageContext {
 
         for entry in res.0 {
             match entry {
-                ast::Entry::Message { id, value, traits } => {
-                    self.entries.insert(id.clone(),
-                                        ast::Entry::Message {
-                                            id: id,
-                                            value: value,
-                                            traits: traits,
-                                        });
+                ast::Entry::Message(ast::Message { id, value, traits }) => {
+                    self.messages.insert(id.clone(),
+                                         ast::Message {
+                                             id: id,
+                                             value: value,
+                                             traits: traits,
+                                         });
                 }
             }
         }
@@ -39,11 +39,11 @@ impl MessageContext {
         Ok(())
     }
 
-    pub fn get_message(&self, id: &str) -> Option<&ast::Value> {
-        self.entries.get(id)
+    pub fn get_message(&self, id: &str) -> Option<&ast::Message> {
+        self.messages.get(id)
     }
 
-    pub fn format(&self, value: &ast::Value) -> Result<String, ContextError> {
+    pub fn format(&self, value: &ast::Message) -> Result<String, ContextError> {
         match resolve(self, value) {
             Ok(msg) => Ok(msg),
             Err(_) => Err(ContextError::Generic),

--- a/src/context/resolver.rs
+++ b/src/context/resolver.rs
@@ -7,6 +7,6 @@ pub enum ResolverError {
     Generic,
 }
 
-pub fn resolve(ctx: &MessageContext, entity: &ast::Entry) -> Result<String, ResolverError> {
-    return Ok(format!("{:?}", entity));
+pub fn resolve(ctx: &MessageContext, message: &ast::Message) -> Result<String, ResolverError> {
+    return Ok(format!("{:?}", message));
 }

--- a/src/syntax/runtime/ast.rs
+++ b/src/syntax/runtime/ast.rs
@@ -2,15 +2,18 @@
 pub struct Resource(pub Vec<Entry>);
 
 #[derive(Debug, PartialEq)]
+pub enum Entry {
+    Message(Message),
+}
+
+#[derive(Debug, PartialEq)]
 pub struct Identifier(String);
 
 #[derive(Debug, PartialEq)]
-pub enum Entry {
-    Message {
-        id: String,
-        value: Option<Pattern>,
-        traits: Option<Vec<Member>>,
-    },
+pub struct Message {
+    pub id: String,
+    pub value: Option<Pattern>,
+    pub traits: Option<Vec<Member>>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/syntax/runtime/parser.rs
+++ b/src/syntax/runtime/parser.rs
@@ -90,7 +90,8 @@ pub fn parse(source: &str) -> Result<ast::Resource> {
 
     let mut entries = vec![];
 
-    let entry = get_entity(&mut ps)?;
+    let message = get_entity(&mut ps)?;
+    let entry = ast::Entry::Message(message);
 
     entries.push(entry);
 
@@ -98,7 +99,7 @@ pub fn parse(source: &str) -> Result<ast::Resource> {
     Ok(res)
 }
 
-fn get_entity<I>(ps: &mut MultiPeek<I>) -> Result<ast::Entry>
+fn get_entity<I>(ps: &mut MultiPeek<I>) -> Result<ast::Message>
     where I: Iterator<Item = char>
 {
     let id = get_identifier(ps)?;
@@ -111,7 +112,7 @@ fn get_entity<I>(ps: &mut MultiPeek<I>) -> Result<ast::Entry>
 
     let pattern = get_pattern(ps)?;
 
-    Ok(ast::Entry::Message {
+    Ok(ast::Message {
         id: id,
         value: Some(pattern),
         traits: None,

--- a/src/syntax/runtime/parser.rs
+++ b/src/syntax/runtime/parser.rs
@@ -91,9 +91,7 @@ pub fn parse(source: &str) -> Result<ast::Resource> {
     let mut entries = vec![];
 
     let message = get_entity(&mut ps)?;
-    let entry = ast::Entry::Message(message);
-
-    entries.push(entry);
+    entries.push(ast::Entry::Message(message));
 
     let res = ast::Resource(entries);
     Ok(res)


### PR DESCRIPTION
This aligns the `MessageContext` public API to that of its JS equivalent. `format` takes a Value object which must be first acquired via `get_message`.