### PR TITLE
Parserstream2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 
 [dependencies]
-itertools = { git = "https://github.com/bluss/rust-itertools" }
 getopts = "0.2.14"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
 
+#[cfg(test)]
 extern crate test;
 
 #[cfg(test)]

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -20,6 +20,7 @@ pub enum Entry {
     Message(Message),
     Comment(Comment),
     Section(Section),
+    Junk(JunkEntry),
 }
 
 #[derive(Debug, PartialEq)]
@@ -98,4 +99,9 @@ pub enum Expression {
         obj: Box<Expression>,
         key: MemberKey,
     },
+}
+
+#[derive(Debug, PartialEq)]
+pub struct JunkEntry {
+    body: String,
 }

--- a/src/syntax/errors.rs
+++ b/src/syntax/errors.rs
@@ -1,4 +1,5 @@
 #[derive(Debug)]
 pub enum ParserError {
     Generic,
+    ExpectedToken { token: char },
 }

--- a/src/syntax/errors.rs
+++ b/src/syntax/errors.rs
@@ -6,3 +6,48 @@ pub enum ParserError {
     ExpectedField { field: String },
     MissingField { fields: Vec<String> },
 }
+
+fn get_line_for_pos(source: &str, pos: usize) -> (usize, usize) {
+    let mut lines = source.lines();
+    let mut ptr = 0;
+    let mut line_num = 0;
+
+    while let Some(line) = lines.next() {
+        let line_len = line.len();
+        line_num += 1;
+
+        if ptr + line_len > pos {
+            return (ptr, line_num);
+        }
+
+    }
+    return (0, 0);
+}
+
+pub fn get_error_slice(source: &str, start: usize) -> &str {
+    let len = source.len();
+
+    let mut start_pos = 0;
+    let mut slice_len = 10;
+
+    //println!("len: {:?}", len);
+    if len <= slice_len {
+        start_pos = 0;
+        slice_len = len;
+    } else if start + slice_len >= len {
+        start_pos = len - slice_len - 1;
+    } else {
+        start_pos = start;
+    }
+
+    // println!("start_pos: {:?}", start_pos);
+    // println!("slice_len: {:?}", slice_len);
+
+    let mut iter = source.chars();
+    if start_pos > 0 {
+        iter.by_ref().nth(start_pos - 1);
+    }
+    let slice = iter.as_str();
+    let endp = slice.char_indices().nth(slice_len).map(|(n, _)| n).unwrap_or(len);
+    return &slice[..endp];
+}

--- a/src/syntax/errors.rs
+++ b/src/syntax/errors.rs
@@ -2,4 +2,7 @@
 pub enum ParserError {
     Generic,
     ExpectedToken { token: char },
+    ExpectedCharRange { range: String },
+    ExpectedField { field: String },
+    MissingField { fields: Vec<String> },
 }

--- a/src/syntax/errors.rs
+++ b/src/syntax/errors.rs
@@ -7,30 +7,12 @@ pub enum ParserError {
     MissingField { fields: Vec<String> },
 }
 
-fn get_line_for_pos(source: &str, pos: usize) -> (usize, usize) {
-    let mut lines = source.lines();
-    let mut ptr = 0;
-    let mut line_num = 0;
-
-    while let Some(line) = lines.next() {
-        let line_len = line.len();
-        line_num += 1;
-
-        if ptr + line_len > pos {
-            return (ptr, line_num);
-        }
-
-    }
-    return (0, 0);
-}
-
 pub fn get_error_slice(source: &str, start: usize) -> &str {
     let len = source.len();
 
-    let mut start_pos = 0;
+    let start_pos;
     let mut slice_len = 10;
 
-    //println!("len: {:?}", len);
     if len <= slice_len {
         start_pos = 0;
         slice_len = len;
@@ -39,9 +21,6 @@ pub fn get_error_slice(source: &str, start: usize) -> &str {
     } else {
         start_pos = start;
     }
-
-    // println!("start_pos: {:?}", start_pos);
-    // println!("slice_len: {:?}", slice_len);
 
     let mut iter = source.chars();
     if start_pos > 0 {

--- a/src/syntax/iter.rs
+++ b/src/syntax/iter.rs
@@ -1,0 +1,150 @@
+use std::iter::Fuse;
+
+#[derive(Clone, Debug)]
+pub struct ParserStream<I>
+    where I: Iterator
+{
+    iter: Fuse<I>,
+    pub buf: Vec<char>,
+    peek_index: i32,
+    index: i32,
+
+    pub ch: Option<char>,
+
+    iter_end: bool,
+    peek_end: bool,
+}
+
+impl<I: Iterator<Item = char>> ParserStream<I> {
+    pub fn current(&mut self) -> Option<char> {
+        self.ch
+    }
+
+    pub fn current_is(&mut self, ch: char) -> bool {
+        self.ch == Some(ch)
+    }
+
+    pub fn current_peek(&self) -> Option<char> {
+        let diff = self.peek_index - self.index;
+
+        if diff == 0 {
+            return self.ch;
+        }
+
+        if self.peek_end {
+            return None;
+        }
+
+        return Some(self.buf[(diff - 1) as usize]);
+    }
+
+    pub fn current_peek_is(&mut self, ch: char) -> bool {
+        match self.current_peek() {
+            Some(c) => ch == c,
+            None => false,
+        }
+    }
+
+    pub fn peek(&mut self) -> Option<char> {
+        if !self.peek_end {
+            self.peek_index += 1;
+        }
+        match self.iter.next() {
+            Some(c) => {
+                self.buf.push(c);
+                let diff = (self.peek_index - self.index) as usize;
+                return Some(self.buf[diff - 1]);
+            }
+            None => {
+                self.peek_end = true;
+                return None;
+            }
+        }
+    }
+
+    pub fn get_index(&self) -> i32 {
+        self.index
+    }
+
+    pub fn get_peek_index(&self) -> i32 {
+        return self.peek_index;
+    }
+
+    pub fn has_more(&mut self) -> bool {
+        let ret = self.peek().is_some();
+
+        self.reset_peek();
+
+        ret
+    }
+
+    pub fn peek_char_is(&mut self, c: char) -> bool {
+        if self.peek_end {
+            return false;
+        }
+        let ret = match self.peek() {
+            Some(ch) if ch == c => true,
+            _ => false,
+        };
+
+        self.peek_index -= 1;
+        return ret;
+    }
+
+    pub fn reset_peek(&mut self) {
+        self.peek_index = self.index;
+    }
+
+    pub fn skip_to_peek(&mut self) {
+        let diff = self.peek_index - self.index;
+
+        for _ in 0..diff {
+            self.ch = Some(self.buf.remove(0));
+        }
+
+        self.index = self.peek_index;
+    }
+}
+
+impl<I> Iterator for ParserStream<I>
+    where I: Iterator<Item = char>
+{
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+
+        if self.buf.is_empty() {
+            self.ch = self.iter.next();
+        } else {
+            self.ch = Some(self.buf.remove(0));
+        }
+
+        if !self.iter_end {
+            self.index += 1;
+        }
+
+        if self.ch.is_none() {
+            self.iter_end = true;
+            self.peek_end = true;
+        }
+
+        self.peek_index = self.index;
+
+        self.ch
+    }
+}
+
+pub fn parserstream<I>(iterable: I) -> ParserStream<I::IntoIter>
+    where I: IntoIterator
+{
+    ParserStream {
+        iter: iterable.into_iter().fuse(),
+        buf: vec![],
+        peek_index: -1,
+        index: -1,
+        ch: None,
+
+        iter_end: false,
+        peek_end: false,
+    }
+}

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -2,5 +2,6 @@ pub mod ast;
 pub mod parser;
 pub mod errors;
 pub mod stream;
+pub mod iter;
 
 pub use self::parser::parse;

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1,8 +1,9 @@
 pub use super::errors::ParserError;
 
 use super::errors::get_error_slice;
-use super::stream::ParserStream;
-use super::stream::parserstream;
+use super::iter::ParserStream;
+use super::iter::parserstream;
+use super::stream::FTLParserStream;
 
 use std::result;
 

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1,5 +1,6 @@
 pub use super::errors::ParserError;
 
+use super::errors::get_error_slice;
 use super::stream::ParserStream;
 use super::stream::parserstream;
 
@@ -8,46 +9,6 @@ use std::result;
 use super::ast;
 
 type Result<T> = result::Result<T, ParserError>;
-
-fn get_line_for_pos(source: &str, pos: usize) -> (usize, usize) {
-    let mut lines = source.lines();
-    let mut ptr = 0;
-    let mut line_num = 0;
-
-    while let Some(line) = lines.next() {
-        let line_len = line.len();
-        line_num += 1;
-
-        if ptr + line_len > pos {
-            return (ptr, line_num);
-        }
-
-    }
-    return (0, 0);
-}
-
-fn get_error_slice(source: &str, start: usize) -> &str {
-    let slice_len = 10;
-    let len = source.len();
-
-    let mut start_pos;
-    let mut end_pos;
-    if start + slice_len > len {
-        start_pos = 0;
-        end_pos = slice_len;
-    } else {
-        start_pos = start - slice_len;
-        end_pos = slice_len;
-    }
-
-    let mut iter = source.chars();
-    if start_pos > 0 {
-        iter.by_ref().nth(start_pos - 1);
-    }
-    let slice = iter.as_str();
-    let endp = slice.char_indices().nth(end_pos).map(|(n, _)| n).unwrap_or(len);
-    return &slice[..endp];
-}
 
 pub fn parse(source: &str) -> Result<ast::Resource> {
 

--- a/src/syntax/stream.rs
+++ b/src/syntax/stream.rs
@@ -251,15 +251,19 @@ impl<I: Iterator<Item = char>> ParserStream<I> {
         return self.current_char_matches(closure);
     }
 
-    pub fn take_id_start(&mut self) -> Option<char> {
+    pub fn take_id_start(&mut self) -> Result<char> {
         let closure = |x| match x {
             'a'...'z' | 'A'...'Z' | '_' => true,
             _ => false,
         };
 
         match self.take_char(closure) {
-            Some(ch) => Some(ch),
-            None => None,
+            Some(ch) => Ok(ch),
+            None => {
+                Err(ParserError::ExpectedCharRange {
+                    range: String::from("'a'...'z' | 'A'...'Z' | '_'"),
+                })
+            }
         }
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,1 @@
+mod syntax;

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,0 +1,196 @@
+extern crate fluent;
+
+use fluent::syntax::stream::parserstream;
+
+#[test]
+fn next() {
+    let mut ps = parserstream("abcd".chars());
+
+    assert_eq!(None, ps.current());
+    assert_eq!(None, ps.get_index());
+
+    assert_eq!(Some('a'), ps.next());
+    assert_eq!(Some('a'), ps.current());
+    assert_eq!(Some(0), ps.get_index());
+
+    assert_eq!(Some('b'), ps.next());
+    assert_eq!(Some('b'), ps.current());
+    assert_eq!(Some(1), ps.get_index());
+
+    assert_eq!(Some('c'), ps.next());
+    assert_eq!(Some('c'), ps.current());
+    assert_eq!(Some(2), ps.get_index());
+
+    assert_eq!(Some('d'), ps.next());
+    assert_eq!(Some('d'), ps.current());
+    assert_eq!(Some(3), ps.get_index());
+
+    assert_eq!(None, ps.next());
+    assert_eq!(Some('d'), ps.current());
+    assert_eq!(Some(3), ps.get_index());
+}
+
+#[test]
+fn peek() {
+    let mut ps = parserstream("abcd".chars());
+
+    assert_eq!(None, ps.current_peek());
+    assert_eq!(None, ps.get_peek_index());
+
+    assert_eq!(Some('a'), ps.peek());
+    assert_eq!(Some('a'), ps.current_peek());
+    assert_eq!(Some(0), ps.get_peek_index());
+
+    assert_eq!(Some('b'), ps.peek());
+    assert_eq!(Some('b'), ps.current_peek());
+    assert_eq!(Some(1), ps.get_peek_index());
+
+    assert_eq!(Some('c'), ps.peek());
+    assert_eq!(Some('c'), ps.current_peek());
+    assert_eq!(Some(2), ps.get_peek_index());
+
+    assert_eq!(Some('d'), ps.peek());
+    assert_eq!(Some('d'), ps.current_peek());
+    assert_eq!(Some(3), ps.get_peek_index());
+
+    assert_eq!(None, ps.peek());
+    assert_eq!(Some('d'), ps.current_peek());
+    assert_eq!(Some(3), ps.get_peek_index());
+}
+
+#[test]
+fn peek_and_next() {
+    let mut ps = parserstream("abcd".chars());
+
+    assert_eq!(Some('a'), ps.peek());
+    assert_eq!(Some(0), ps.get_peek_index());
+    assert_eq!(None, ps.get_index());
+
+    assert_eq!(Some('a'), ps.next());
+    assert_eq!(Some(0), ps.get_peek_index());
+    assert_eq!(Some(0), ps.get_index());
+
+    assert_eq!(Some('b'), ps.peek());
+    assert_eq!(Some(1), ps.get_peek_index());
+    assert_eq!(Some(0), ps.get_index());
+
+    assert_eq!(Some('c'), ps.peek());
+    assert_eq!(Some(2), ps.get_peek_index());
+    assert_eq!(Some(0), ps.get_index());
+
+    assert_eq!(Some('b'), ps.next());
+    assert_eq!(Some(1), ps.get_peek_index());
+    assert_eq!(Some(1), ps.get_index());
+    assert_eq!(Some('b'), ps.current());
+    assert_eq!(Some('b'), ps.current_peek());
+
+    assert_eq!(Some('c'), ps.next());
+    assert_eq!(Some(2), ps.get_peek_index());
+    assert_eq!(Some(2), ps.get_index());
+    assert_eq!(Some('c'), ps.current());
+    assert_eq!(Some('c'), ps.current_peek());
+
+    assert_eq!(Some('d'), ps.peek());
+    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(Some(2), ps.get_index());
+
+    assert_eq!(Some('d'), ps.next());
+    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(Some('d'), ps.current());
+    assert_eq!(Some('d'), ps.current_peek());
+
+    assert_eq!(None, ps.peek());
+    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(Some('d'), ps.current());
+    assert_eq!(Some('d'), ps.current_peek());
+
+    assert_eq!(None, ps.peek());
+    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(Some(3), ps.get_index());
+
+    assert_eq!(None, ps.next());
+    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(Some(3), ps.get_index());
+}
+
+#[test]
+fn skip_to_peek() {
+    let mut ps = parserstream("abcd".chars());
+
+    ps.peek();
+    ps.peek();
+    ps.peek();
+
+    ps.skip_to_peek();
+
+    assert_eq!(Some('c'), ps.current());
+    assert_eq!(Some('c'), ps.current_peek());
+    assert_eq!(Some(2), ps.get_peek_index());
+    assert_eq!(Some(2), ps.get_index());
+
+    ps.peek();
+
+    assert_eq!(Some('c'), ps.current());
+    assert_eq!(Some('d'), ps.current_peek());
+    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(Some(2), ps.get_index());
+
+    ps.next();
+
+    assert_eq!(Some('d'), ps.current());
+    assert_eq!(Some('d'), ps.current_peek());
+    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(Some(3), ps.get_index());
+}
+
+#[test]
+fn reset_peek() {
+    let mut ps = parserstream("abcd".chars());
+
+    ps.next();
+    ps.peek();
+    ps.peek();
+    ps.reset_peek();
+
+    assert_eq!(Some('a'), ps.current());
+    assert_eq!(Some('a'), ps.current_peek());
+    assert_eq!(Some(0), ps.get_peek_index());
+    assert_eq!(Some(0), ps.get_index());
+
+    ps.peek();
+
+    assert_eq!(Some('a'), ps.current());
+    assert_eq!(Some('b'), ps.current_peek());
+    assert_eq!(Some(1), ps.get_peek_index());
+    assert_eq!(Some(0), ps.get_index());
+
+    ps.peek();
+    ps.peek();
+    ps.peek();
+    ps.peek();
+    ps.reset_peek();
+
+    assert_eq!(Some('a'), ps.current());
+    assert_eq!(Some('a'), ps.current_peek());
+    assert_eq!(Some(0), ps.get_peek_index());
+    assert_eq!(Some(0), ps.get_index());
+}
+
+#[test]
+fn peek_char_is() {
+    let mut ps = parserstream("abcd".chars());
+
+    ps.next();
+    ps.peek();
+
+    assert_eq!(ps.peek_char_is('c'), true);
+
+    assert_eq!(Some('a'), ps.current());
+    assert_eq!(Some('b'), ps.current_peek());
+
+    ps.skip_to_peek();
+
+    assert_eq!(Some('b'), ps.current());
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -7,27 +7,27 @@ fn next() {
     let mut ps = parserstream("abcd".chars());
 
     assert_eq!(None, ps.current());
-    assert_eq!(None, ps.get_index());
+    assert_eq!(-1, ps.get_index());
 
     assert_eq!(Some('a'), ps.next());
     assert_eq!(Some('a'), ps.current());
-    assert_eq!(Some(0), ps.get_index());
+    assert_eq!(0, ps.get_index());
 
     assert_eq!(Some('b'), ps.next());
     assert_eq!(Some('b'), ps.current());
-    assert_eq!(Some(1), ps.get_index());
+    assert_eq!(1, ps.get_index());
 
     assert_eq!(Some('c'), ps.next());
     assert_eq!(Some('c'), ps.current());
-    assert_eq!(Some(2), ps.get_index());
+    assert_eq!(2, ps.get_index());
 
     assert_eq!(Some('d'), ps.next());
     assert_eq!(Some('d'), ps.current());
-    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(3, ps.get_index());
 
     assert_eq!(None, ps.next());
-    assert_eq!(Some('d'), ps.current());
-    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(None, ps.current());
+    assert_eq!(4, ps.get_index());
 }
 
 #[test]
@@ -35,27 +35,27 @@ fn peek() {
     let mut ps = parserstream("abcd".chars());
 
     assert_eq!(None, ps.current_peek());
-    assert_eq!(None, ps.get_peek_index());
+    assert_eq!(-1, ps.get_peek_index());
 
     assert_eq!(Some('a'), ps.peek());
     assert_eq!(Some('a'), ps.current_peek());
-    assert_eq!(Some(0), ps.get_peek_index());
+    assert_eq!(0, ps.get_peek_index());
 
     assert_eq!(Some('b'), ps.peek());
     assert_eq!(Some('b'), ps.current_peek());
-    assert_eq!(Some(1), ps.get_peek_index());
+    assert_eq!(1, ps.get_peek_index());
 
     assert_eq!(Some('c'), ps.peek());
     assert_eq!(Some('c'), ps.current_peek());
-    assert_eq!(Some(2), ps.get_peek_index());
+    assert_eq!(2, ps.get_peek_index());
 
     assert_eq!(Some('d'), ps.peek());
     assert_eq!(Some('d'), ps.current_peek());
-    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(3, ps.get_peek_index());
 
     assert_eq!(None, ps.peek());
-    assert_eq!(Some('d'), ps.current_peek());
-    assert_eq!(Some(3), ps.get_peek_index());
+    assert_eq!(None, ps.current_peek());
+    assert_eq!(4, ps.get_peek_index());
 }
 
 #[test]
@@ -63,56 +63,56 @@ fn peek_and_next() {
     let mut ps = parserstream("abcd".chars());
 
     assert_eq!(Some('a'), ps.peek());
-    assert_eq!(Some(0), ps.get_peek_index());
-    assert_eq!(None, ps.get_index());
+    assert_eq!(0, ps.get_peek_index());
+    assert_eq!(-1, ps.get_index());
 
     assert_eq!(Some('a'), ps.next());
-    assert_eq!(Some(0), ps.get_peek_index());
-    assert_eq!(Some(0), ps.get_index());
+    assert_eq!(0, ps.get_peek_index());
+    assert_eq!(0, ps.get_index());
 
     assert_eq!(Some('b'), ps.peek());
-    assert_eq!(Some(1), ps.get_peek_index());
-    assert_eq!(Some(0), ps.get_index());
+    assert_eq!(1, ps.get_peek_index());
+    assert_eq!(0, ps.get_index());
 
     assert_eq!(Some('c'), ps.peek());
-    assert_eq!(Some(2), ps.get_peek_index());
-    assert_eq!(Some(0), ps.get_index());
+    assert_eq!(2, ps.get_peek_index());
+    assert_eq!(0, ps.get_index());
 
     assert_eq!(Some('b'), ps.next());
-    assert_eq!(Some(1), ps.get_peek_index());
-    assert_eq!(Some(1), ps.get_index());
+    assert_eq!(1, ps.get_peek_index());
+    assert_eq!(1, ps.get_index());
     assert_eq!(Some('b'), ps.current());
     assert_eq!(Some('b'), ps.current_peek());
 
     assert_eq!(Some('c'), ps.next());
-    assert_eq!(Some(2), ps.get_peek_index());
-    assert_eq!(Some(2), ps.get_index());
+    assert_eq!(2, ps.get_peek_index());
+    assert_eq!(2, ps.get_index());
     assert_eq!(Some('c'), ps.current());
     assert_eq!(Some('c'), ps.current_peek());
 
     assert_eq!(Some('d'), ps.peek());
-    assert_eq!(Some(3), ps.get_peek_index());
-    assert_eq!(Some(2), ps.get_index());
+    assert_eq!(3, ps.get_peek_index());
+    assert_eq!(2, ps.get_index());
 
     assert_eq!(Some('d'), ps.next());
-    assert_eq!(Some(3), ps.get_peek_index());
-    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(3, ps.get_peek_index());
+    assert_eq!(3, ps.get_index());
     assert_eq!(Some('d'), ps.current());
     assert_eq!(Some('d'), ps.current_peek());
 
     assert_eq!(None, ps.peek());
-    assert_eq!(Some(3), ps.get_peek_index());
-    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(4, ps.get_peek_index());
+    assert_eq!(3, ps.get_index());
     assert_eq!(Some('d'), ps.current());
-    assert_eq!(Some('d'), ps.current_peek());
+    assert_eq!(None, ps.current_peek());
 
     assert_eq!(None, ps.peek());
-    assert_eq!(Some(3), ps.get_peek_index());
-    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(4, ps.get_peek_index());
+    assert_eq!(3, ps.get_index());
 
     assert_eq!(None, ps.next());
-    assert_eq!(Some(3), ps.get_peek_index());
-    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(4, ps.get_peek_index());
+    assert_eq!(4, ps.get_index());
 }
 
 #[test]
@@ -127,22 +127,22 @@ fn skip_to_peek() {
 
     assert_eq!(Some('c'), ps.current());
     assert_eq!(Some('c'), ps.current_peek());
-    assert_eq!(Some(2), ps.get_peek_index());
-    assert_eq!(Some(2), ps.get_index());
+    assert_eq!(2, ps.get_peek_index());
+    assert_eq!(2, ps.get_index());
 
     ps.peek();
 
     assert_eq!(Some('c'), ps.current());
     assert_eq!(Some('d'), ps.current_peek());
-    assert_eq!(Some(3), ps.get_peek_index());
-    assert_eq!(Some(2), ps.get_index());
+    assert_eq!(3, ps.get_peek_index());
+    assert_eq!(2, ps.get_index());
 
     ps.next();
 
     assert_eq!(Some('d'), ps.current());
     assert_eq!(Some('d'), ps.current_peek());
-    assert_eq!(Some(3), ps.get_peek_index());
-    assert_eq!(Some(3), ps.get_index());
+    assert_eq!(3, ps.get_peek_index());
+    assert_eq!(3, ps.get_index());
 }
 
 #[test]
@@ -156,15 +156,15 @@ fn reset_peek() {
 
     assert_eq!(Some('a'), ps.current());
     assert_eq!(Some('a'), ps.current_peek());
-    assert_eq!(Some(0), ps.get_peek_index());
-    assert_eq!(Some(0), ps.get_index());
+    assert_eq!(0, ps.get_peek_index());
+    assert_eq!(0, ps.get_index());
 
     ps.peek();
 
     assert_eq!(Some('a'), ps.current());
     assert_eq!(Some('b'), ps.current_peek());
-    assert_eq!(Some(1), ps.get_peek_index());
-    assert_eq!(Some(0), ps.get_index());
+    assert_eq!(1, ps.get_peek_index());
+    assert_eq!(0, ps.get_index());
 
     ps.peek();
     ps.peek();
@@ -174,8 +174,8 @@ fn reset_peek() {
 
     assert_eq!(Some('a'), ps.current());
     assert_eq!(Some('a'), ps.current_peek());
-    assert_eq!(Some(0), ps.get_peek_index());
-    assert_eq!(Some(0), ps.get_index());
+    assert_eq!(0, ps.get_peek_index());
+    assert_eq!(0, ps.get_index());
 }
 
 #[test]

--- a/tests/syntax/fixtures.rs
+++ b/tests/syntax/fixtures.rs
@@ -1,13 +1,13 @@
 extern crate fluent;
 extern crate glob;
 
-use glob::glob;
+use self::glob::glob;
 use std::io::prelude::*;
 use std::fs::File;
 use std::io;
 
-use fluent::syntax::parse;
-use fluent::syntax::parser::ParserError;
+use self::fluent::syntax::parse;
+use self::fluent::syntax::parser::ParserError;
 
 fn read_file(path: &str) -> Result<String, io::Error> {
     let mut f = try!(File::open(path));

--- a/tests/syntax/iter.rs
+++ b/tests/syntax/iter.rs
@@ -1,6 +1,6 @@
 extern crate fluent;
 
-use fluent::syntax::stream::parserstream;
+use self::fluent::syntax::iter::parserstream;
 
 #[test]
 fn next() {

--- a/tests/syntax/mod.rs
+++ b/tests/syntax/mod.rs
@@ -1,0 +1,2 @@
+mod iter;
+mod fixtures;


### PR DESCRIPTION
This branch moves us away from MultiPeek to our custom iterator which has multiple new features like indexing (required for errors) and current/current_peek which makes the parser much faster.

In the new structure I keep the four files:
1. syntax/iter.rs - the StreamParser iterator
2. syntax/stream.rs - FTL specific traits for StreamParser
3. syntax/parser.rs - Parser
4. syntax/errors.rs - Errors

I'll document the files and I hope to move synax/iter.rs eventually either to upstream to itertools crate, or possibly to fork it.
For now, I'll keep it small and clean.

Very preliminary error reporting is also added. I'll build from here.