### PR TITLE
Resolver 0.1

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::syntax::ast;
 use super::syntax::parse;
 use super::types::FluentValue;
-use super::resolve::resolve;
+use super::resolve::{Env, ResolveValue};
 
 
 #[allow(dead_code)]
@@ -78,12 +78,12 @@ impl MessageContext {
     }
 
 
-    pub fn format(
+    pub fn format<T: ResolveValue>(
         &self,
-        message: &ast::Message,
+        resolvable: &T,
         args: Option<&HashMap<&str, FluentValue>>,
     ) -> Option<String> {
-        let value = resolve(self, args, message);
-        value.map(|value| value.format())
+        let env = Env { ctx: self, args };
+        resolvable.to_value(&env).map(|value| value.format())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(slice_patterns)]
+
 #![cfg_attr(test, feature(test))]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(slice_patterns)]
-
 #![cfg_attr(test, feature(test))]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(box_patterns)]
+
 #![cfg_attr(test, feature(test))]
 
 #[cfg(test)]

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -125,12 +125,16 @@ impl ResolveValue for ast::Expression {
                 let variants = message.as_ref().and_then(|message| {
                     message.value.as_ref()
                 }).and_then(|pattern| {
-                    match pattern.elements.as_slice() {
-                       &[ast::PatternElement::Placeable(ast::Placeable {
+                    if pattern.elements.len() > 1 {
+                        return None;
+                    }
+
+                    match pattern.elements.first() {
+                       Some(&ast::PatternElement::Placeable(ast::Placeable {
                            expression: ast::Expression::SelectExpression {
                                expression: None, ref variants
                            }
-                       })] => Some(variants),
+                       })) => Some(variants),
                         _ => None
                     }
                 });

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -120,17 +120,18 @@ impl ResolveValue for ast::Expression {
             } => {
                 let selector = expression.as_ref().and_then(|expr| expr.to_value(env));
 
-                if let Some(selector) = selector {
+                if let Some(ref selector) = selector {
                     for variant in variants {
                         match variant.key {
                             ast::VarKey::Symbol(ref symbol) => {
-                                if selector == FluentValue::from(symbol.name.clone()) {
+                                let key = FluentValue::from(symbol.name.clone());
+                                if key.matches(env, selector) {
                                     return variant.value.to_value(env);
                                 }
                             }
                             ast::VarKey::Number(ref number) => {
-                                if let Some(number) = number.to_value(env) {
-                                    if selector == number {
+                                if let Some(key) = number.to_value(env) {
+                                    if key.matches(env, selector) {
                                         return variant.value.to_value(env);
                                     }
                                 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -107,6 +107,19 @@ impl ResolveValue for ast::Expression {
 
                 select_default(variants).and_then(|variant| variant.value.to_value(env))
             }
+            ast::Expression::AttributeExpression { ref id, ref name } => {
+                let attributes = env.ctx.get_message(&id.name).as_ref().and_then(|message| {
+                    message.attributes.as_ref()
+                });
+                if let Some(attributes) = attributes {
+                    for attribute in attributes {
+                        if attribute.id.name == name.name {
+                            return attribute.value.to_value(env);
+                        }
+                    }
+                }
+                None
+            }
             _ => unimplemented!(),
         }
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -84,7 +84,9 @@ impl ResolveValue for ast::Expression {
                 expression: Some(box ast::Expression::MessageReference { ref id }),
                 ref variants,
             } => {
-                let tags = env.ctx.get_message(&id.name).and_then(|message| message.tags.as_ref());
+                let tags = env.ctx.get_message(&id.name).and_then(
+                    |message| message.tags.as_ref(),
+                );
 
                 if let Some(tags) = tags {
                     for variant in variants {
@@ -96,7 +98,7 @@ impl ResolveValue for ast::Expression {
                                     }
                                 }
                             }
-                            _ => ()
+                            _ => (),
                         }
                     }
                 }
@@ -145,22 +147,23 @@ impl ResolveValue for ast::Expression {
             }
             ast::Expression::VariantExpression { ref id, ref key } => {
                 let message = env.ctx.get_message(&id.name);
-                let variants = message.as_ref().and_then(|message| {
-                    message.value.as_ref()
-                }).and_then(|pattern| {
-                    if pattern.elements.len() > 1 {
-                        return None;
-                    }
+                let variants = message
+                    .as_ref()
+                    .and_then(|message| message.value.as_ref())
+                    .and_then(|pattern| {
+                        if pattern.elements.len() > 1 {
+                            return None;
+                        }
 
-                    match pattern.elements.first() {
-                       Some(&ast::PatternElement::Placeable(ast::Placeable {
+                        match pattern.elements.first() {
+                            Some(&ast::PatternElement::Placeable(ast::Placeable {
                            expression: ast::Expression::SelectExpression {
                                expression: None, ref variants
                            }
                        })) => Some(variants),
-                        _ => None
-                    }
-                });
+                            _ => None,
+                        }
+                    });
 
                 if let Some(variants) = variants {
                     for variant in variants {
@@ -172,7 +175,8 @@ impl ResolveValue for ast::Expression {
                     return select_default(variants).and_then(|variant| variant.value.to_value(env));
                 }
 
-                message.as_ref()
+                message
+                    .as_ref()
                     .and_then(|message| message.value.as_ref())
                     .and_then(|pattern| pattern.to_value(env))
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -46,9 +46,7 @@ impl ResolveValue for ast::Placeable {
 
 impl ResolveValue for ast::Number {
     fn to_value(&self, _env: &Env) -> Option<FluentValue> {
-        f32::from_str(&self.value).ok().map(
-            |num| FluentValue::from(num),
-        )
+        f32::from_str(&self.value).ok().map(FluentValue::from)
     }
 }
 
@@ -72,9 +70,9 @@ impl ResolveValue for ast::Expression {
                     .and_then(|pattern| pattern.to_value(env))
             }
             ast::Expression::ExternalArgument { ref id } => {
-                env.args.and_then(|args| args.get(&id.name.as_ref())).map(
-                    |arg| arg.clone(),
-                )
+                env.args
+                    .and_then(|args| args.get(&id.name.as_ref()))
+                    .cloned()
             }
             ast::Expression::SelectExpression {
                 expression: None,
@@ -90,15 +88,12 @@ impl ResolveValue for ast::Expression {
 
                 if let Some(tags) = tags {
                     for variant in variants {
-                        match variant.key {
-                            ast::VarKey::Symbol(ref symbol) => {
-                                for tag in tags.iter() {
-                                    if symbol.name == tag.name.name {
-                                        return variant.value.to_value(env);
-                                    }
+                        if let ast::VarKey::Symbol(ref symbol) = variant.key {
+                            for tag in tags.iter() {
+                                if symbol.name == tag.name.name {
+                                    return variant.value.to_value(env);
                                 }
                             }
-                            _ => (),
                         }
                     }
                 }
@@ -186,7 +181,7 @@ impl ResolveValue for ast::Expression {
     }
 }
 
-fn select_default(variants: &Vec<ast::Variant>) -> Option<&ast::Variant> {
+fn select_default(variants: &[ast::Variant]) -> Option<&ast::Variant> {
     for variant in variants {
         if variant.default {
             return Some(variant);

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,6 +33,6 @@ impl From<f32> for FluentValue {
 
 impl From<i8> for FluentValue {
     fn from(n: i8) -> Self {
-        FluentValue::Number(n as f32)
+        FluentValue::Number(f32::from(n))
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,19 @@
+use std::f32;
+use super::resolve::Env;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum FluentValue {
     String(String),
     Number(f32),
+}
+
+// XXX Replace this with a proper plural rule based on the MessageContext's locales.
+fn mock_plural(num: &f32) -> &'static str {
+    if (*num - 1.0).abs() < f32::EPSILON {
+        "one"
+    } else {
+        "other"
+    }
 }
 
 impl FluentValue {
@@ -9,6 +21,17 @@ impl FluentValue {
         match *self {
             FluentValue::String(ref s) => s.clone(),
             FluentValue::Number(ref n) => format!("{}", n),
+        }
+    }
+
+    pub fn matches(&self, _env: &Env, other: &FluentValue) -> bool {
+        match (self, other) {
+            (&FluentValue::String(ref a), &FluentValue::String(ref b)) => a == b,
+            (&FluentValue::Number(ref a), &FluentValue::Number(ref b)) => {
+                (a - b).abs() < f32::EPSILON
+            }
+            (&FluentValue::String(ref a), &FluentValue::Number(ref b)) => a == mock_plural(b),
+            (&FluentValue::Number(..), &FluentValue::String(..)) => false,
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,5 @@
 mod syntax;
+mod resolve_attribute;
 mod resolve_attribute_expression;
 mod resolve_external_argument;
 mod resolve_message_reference;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,5 @@
 mod syntax;
+mod resolve_attribute_expression;
 mod resolve_external_argument;
 mod resolve_message_reference;
 mod resolve_select_expression;

--- a/tests/resolve_attribute.rs
+++ b/tests/resolve_attribute.rs
@@ -1,0 +1,26 @@
+extern crate fluent;
+
+use self::fluent::context::MessageContext;
+
+#[test]
+fn format_attribute() {
+    let mut ctx = MessageContext::new("x-testing");
+
+    ctx.add_messages(
+        "
+foo = Foo
+    .attr = Foo Attr
+",
+    );
+
+    if let Some(attributes) = ctx.get_message("foo").and_then(
+        |message| message.attributes.as_ref(),
+    )
+    {
+        let value = attributes.first().and_then(
+            |attribute| ctx.format(attribute, None),
+        );
+
+        assert_eq!(value, Some("Foo Attr".to_string()));
+    }
+}

--- a/tests/resolve_attribute_expression.rs
+++ b/tests/resolve_attribute_expression.rs
@@ -1,0 +1,55 @@
+extern crate fluent;
+
+use self::fluent::context::MessageContext;
+
+#[test]
+fn attribute_expression() {
+    let mut ctx = MessageContext::new("x-testing");
+
+    ctx.add_messages(
+        "
+foo = Foo
+    .attr = Foo Attr
+bar
+    .attr = Bar Attr
+
+use-foo = { foo }
+use-foo-attr = { foo.attr }
+use-bar = { bar }
+use-bar-attr = { bar.attr }
+
+missing-attr = { foo.missing }
+missing-missing = { missing.missing }
+",
+    );
+
+    let value = ctx.get_message("use-foo").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Foo".to_string()));
+
+    let value = ctx.get_message("use-foo-attr").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Foo Attr".to_string()));
+
+    let value = ctx.get_message("use-bar").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("___".to_string()));
+
+    let value = ctx.get_message("use-bar-attr").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Bar Attr".to_string()));
+
+    let value = ctx.get_message("missing-attr").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("___".to_string()));
+
+    let value = ctx.get_message("missing-missing").and_then(|msg| {
+        ctx.format(msg, None)
+    });
+    assert_eq!(value, Some("___".to_string()));
+}

--- a/tests/resolve_select_expression.rs
+++ b/tests/resolve_select_expression.rs
@@ -244,12 +244,18 @@ use-baz =
 ",
     );
 
-    let value = ctx.get_message("use-foo").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.get_message("use-foo").and_then(
+        |msg| ctx.format(msg, None),
+    );
     assert_eq!(value, Some("Other".to_string()));
 
-    let value = ctx.get_message("use-bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.get_message("use-bar").and_then(
+        |msg| ctx.format(msg, None),
+    );
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx.get_message("use-baz").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.get_message("use-baz").and_then(
+        |msg| ctx.format(msg, None),
+    );
     assert_eq!(value, Some("Baz 2".to_string()));
 }

--- a/tests/resolve_select_expression.rs
+++ b/tests/resolve_select_expression.rs
@@ -298,3 +298,52 @@ use-baz =
     );
     assert_eq!(value, Some("Baz 2".to_string()));
 }
+
+#[test]
+fn select_expression_attribute_selector() {
+    let mut ctx = MessageContext::new("x-testing");
+
+    ctx.add_messages(
+        "
+foo = Foo
+    .attr = Foo Attr
+
+use-foo =
+    { foo.attr ->
+        [Foo Attr] Foo
+       *[other] Other
+    }
+",
+    );
+
+    let value = ctx.get_message("use-foo").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Foo".to_string()));
+}
+
+#[test]
+fn select_expression_variant_selector() {
+    let mut ctx = MessageContext::new("x-testing");
+
+    ctx.add_messages(
+        "
+foo =
+    {
+       *[a] Foo A
+        [b] Foo B
+    }
+
+use-foo =
+    { foo[b] ->
+        [Foo B] Foo
+       *[other] Other
+    }
+",
+    );
+
+    let value = ctx.get_message("use-foo").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Foo".to_string()));
+}

--- a/tests/resolve_select_expression.rs
+++ b/tests/resolve_select_expression.rs
@@ -79,9 +79,9 @@ bar =
 
 baz =
     { 3.14 ->
-       *[1] Bar 1
-        [3] Bar 3
-        [3.14] Bar Pi
+       *[1] Baz 1
+        [3] Baz 3
+        [3.14] Baz Pi
     }
 ",
     );
@@ -93,7 +93,46 @@ baz =
     assert_eq!(value, Some("Bar 1".to_string()));
 
     let value = ctx.get_message("baz").and_then(|msg| ctx.format(msg, None));
-    assert_eq!(value, Some("Bar Pi".to_string()));
+    assert_eq!(value, Some("Baz Pi".to_string()));
+}
+
+#[test]
+fn select_expression_plurals() {
+    let mut ctx = MessageContext::new("x-testing");
+
+    ctx.add_messages(
+        "
+foo =
+    { 3 ->
+        [one] Foo One
+        [3] Foo 3
+       *[other] Foo Other
+    }
+
+bar =
+    { 1 ->
+        [one] Bar One
+        [2] Bar 2
+       *[other] Bar Other
+    }
+
+baz =
+    { \"one\" ->
+        [1] Bar One
+        [3] Bar 3
+       *[other] Bar Other
+    }
+",
+    );
+
+    let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+    assert_eq!(value, Some("Foo 3".to_string()));
+
+    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    assert_eq!(value, Some("Bar One".to_string()));
+
+    let value = ctx.get_message("baz").and_then(|msg| ctx.format(msg, None));
+    assert_eq!(value, Some("Bar Other".to_string()));
 }
 
 #[test]

--- a/tests/resolve_variant_expression.rs
+++ b/tests/resolve_variant_expression.rs
@@ -27,9 +27,7 @@ missing-missing = { missing[missing] }
 ",
     );
 
-    let value = ctx.get_message("bar").and_then(
-        |msg| ctx.format(msg, None),
-    );
+    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Bar".to_string()));
 
     let value = ctx.get_message("use-foo").and_then(
@@ -37,9 +35,9 @@ missing-missing = { missing[missing] }
     );
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx.get_message("use-foo-missing").and_then(
-        |msg| ctx.format(msg, None),
-    );
+    let value = ctx.get_message("use-foo-missing").and_then(|msg| {
+        ctx.format(msg, None)
+    });
     assert_eq!(value, Some("Foo".to_string()));
 
     let value = ctx.get_message("use-bar").and_then(
@@ -47,19 +45,19 @@ missing-missing = { missing[missing] }
     );
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx.get_message("use-bar-nominative").and_then(
-        |msg| ctx.format(msg, None),
-    );
+    let value = ctx.get_message("use-bar-nominative").and_then(|msg| {
+        ctx.format(msg, None)
+    });
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx.get_message("use-bar-genitive").and_then(
-        |msg| ctx.format(msg, None),
-    );
+    let value = ctx.get_message("use-bar-genitive").and_then(|msg| {
+        ctx.format(msg, None)
+    });
     assert_eq!(value, Some("Bar's".to_string()));
 
-    let value = ctx.get_message("use-bar-missing").and_then(
-        |msg| ctx.format(msg, None),
-    );
+    let value = ctx.get_message("use-bar-missing").and_then(|msg| {
+        ctx.format(msg, None)
+    });
     assert_eq!(value, Some("Bar".to_string()));
 
     let value = ctx.get_message("missing-missing").and_then(|msg| {

--- a/tests/resolve_variant_expression.rs
+++ b/tests/resolve_variant_expression.rs
@@ -1,0 +1,69 @@
+extern crate fluent;
+
+use self::fluent::context::MessageContext;
+
+#[test]
+fn variant_expression() {
+    let mut ctx = MessageContext::new("x-testing");
+
+    ctx.add_messages(
+        "
+foo = Foo
+bar =
+    {
+       *[nominative] Bar
+        [genitive] Bar's
+    }
+
+use-foo = { foo }
+use-foo-missing = { foo[missing] }
+
+use-bar = { bar }
+use-bar-nominative = { bar[nominative] }
+use-bar-genitive = { bar[genitive] }
+use-bar-missing = { bar[missing] }
+
+missing-missing = { missing[missing] }
+",
+    );
+
+    let value = ctx.get_message("bar").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Bar".to_string()));
+
+    let value = ctx.get_message("use-foo").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Foo".to_string()));
+
+    let value = ctx.get_message("use-foo-missing").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Foo".to_string()));
+
+    let value = ctx.get_message("use-bar").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Bar".to_string()));
+
+    let value = ctx.get_message("use-bar-nominative").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Bar".to_string()));
+
+    let value = ctx.get_message("use-bar-genitive").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Bar's".to_string()));
+
+    let value = ctx.get_message("use-bar-missing").and_then(
+        |msg| ctx.format(msg, None),
+    );
+    assert_eq!(value, Some("Bar".to_string()));
+
+    let value = ctx.get_message("missing-missing").and_then(|msg| {
+        ctx.format(msg, None)
+    });
+    assert_eq!(value, Some("___".to_string()));
+}


### PR DESCRIPTION
This depends on #17.

- [x] `AttributeExpression` in placeables and selectors,
- [x] `VariantExpression` in placeables and selectors,
- [x] `MessageRefence` in selectors (using tags),
- [x] `MessageContext::format` is able to format attributes,
- [x] A simple mock-plural rule is used in `FluentValue::matches`,
- [x] `ast::Number` now uses `f32` under the hood.