### PR TITLE
Change formatting in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ use fluent::MessageContext;
 let ctx = MessageContext::new(&["en-US"]);
 ctx.add_messages("hello-world = Hello, world!");
 
-let value = ctx.get_message("hello-world").and_then(
-    |message| ctx.format(message, None),
-);
+let value = ctx.get_message("hello-world")
+               .and_then(|message| ctx.format(message, None));
 
 assert_eq!(value, Some("Hello, world!".to_string()));
 ```


### PR DESCRIPTION
Closure parameters usually follow immediately after the opening parenthesis for the called function.

Chained methods also (subjectively) look nicer when aligned.