### PR TITLE
Add block expressions

### DIFF
--- a/src/intl/mod.rs
+++ b/src/intl/mod.rs
@@ -481,7 +481,7 @@ fn get_plural_rule(loc: &str) -> Option<usize> {
         "zu" => 3,
         _ => return None,
     };
-    return Some(num);
+    Some(num)
 }
 
 pub struct PluralRules {

--- a/tests/fixtures/parser/ftl/02-multiline01.ftl
+++ b/tests/fixtures/parser/ftl/02-multiline01.ftl
@@ -1,14 +1,14 @@
 key1 =
-     | This is a new line
+    This is a new line
 
 key4=
- | <p>
- |   So
- |     Many
- |   Lines
- | </p>
+  <p>
+    So
+      Many
+    Lines
+  </p>
 
 key5 =        
- |<p>
- | Foo
- |</p>
+ <p>
+  Foo
+ </p>

--- a/tests/fixtures/parser/ftl/08-block-expr.ftl
+++ b/tests/fixtures/parser/ftl/08-block-expr.ftl
@@ -1,0 +1,9 @@
+key = { $foo ->
+  [one] One
+ *[other] Other
+}
+
+key2 = {
+    [one] One
+   *[other] Other
+}

--- a/tests/fixtures/parser/ftl/errors/09-block-expr.ftl
+++ b/tests/fixtures/parser/ftl/errors/09-block-expr.ftl
@@ -1,0 +1,7 @@
+key = Test { $foo ->
+  *[other] Value
+}
+
+key = { $foo ->
+  *[other] Value
+} Test

--- a/tests/syntax/errors.rs
+++ b/tests/syntax/errors.rs
@@ -298,3 +298,43 @@ fn private_errors() {
         }
     }
 }
+
+#[test]
+fn block_expr_errors() {
+    let path = "./tests/fixtures/parser/ftl/errors/09-block-expr.ftl";
+    let source = read_file(path).expect("Failed to read");
+    match parse(&source) {
+        Ok(_) => panic!("Expected errors in the file"),
+        Err((_, ref errors)) => {
+            assert_eq!(2, errors.len());
+
+            let error1 = &errors[0];
+
+            assert_eq!(ErrorKind::ExpectedToken { token: ' ' }, error1.kind);
+
+            assert_eq!(
+                Some(ErrorInfo {
+                    slice: "key = Test { $foo ->\n  *[other] Value\n}".to_owned(),
+                    line: 0,
+                    col: 0,
+                    pos: 38,
+                }),
+                error1.info
+            );
+
+            let error2 = &errors[1];
+
+            assert_eq!(ErrorKind::ExpectedEntry, error2.kind);
+
+            assert_eq!(
+                Some(ErrorInfo {
+                    slice: "} Test".to_owned(),
+                    line: 6,
+                    col: 1,
+                    pos: 0,
+                }),
+                error2.info
+            );
+        }
+    }
+}


### PR DESCRIPTION
This is a bit larger diff than I would hope for, but it makes our parser more aligned with the ebnf. I have a high hope to get a more significant rewrite/cleanup of the parser as I make it copy-free, so I'm trying to balance out how much I refactor now.

This gets the 0.5 syntax to work.