### PR TITLE
Remove box_patterns for stable rust 1.23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: rust
 cache: cargo
 rust:
+  - stable
+  - beta
   - nightly
 # Dependencies of kcov, used by coverage
 addons:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(box_patterns)]
-
 //! Fluent is a localization system designed to improve how software is translated.
 //!
 //! The Rust implementation provides the low level components for syntax operations, like parser


### PR DESCRIPTION
As far as I can tell, the fluent crate is not using `box_patterns`. I removed the feature declaration, and after https://github.com/projectfluent/fluent-locale-rs/pull/3 is merged, we should be able to get this building on stable rust 1.23, resolving #42.