### PR TITLE
Support Fluent Syntax 0.5

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -41,6 +41,7 @@ use super::resolve::{Env, ResolveValue};
 pub struct MessageContext<'ctx> {
     pub locales: &'ctx [&'ctx str],
     messages: HashMap<String, ast::Message>,
+    terms: HashMap<String, ast::Term>,
 }
 
 impl<'ctx> MessageContext<'ctx> {
@@ -48,6 +49,7 @@ impl<'ctx> MessageContext<'ctx> {
         MessageContext {
             locales,
             messages: HashMap::new(),
+            terms: HashMap::new(),
         }
     }
 
@@ -59,18 +61,26 @@ impl<'ctx> MessageContext<'ctx> {
         self.messages.get(id)
     }
 
+    pub fn get_term(&self, id: &str) -> Option<&ast::Term> {
+        self.terms.get(id)
+    }
+
     pub fn add_messages(&mut self, source: &str) {
         let res = parse(source).unwrap_or_else(|x| x.0);
 
         for entry in res.body {
             let id = match entry {
                 ast::Entry::Message(ast::Message { ref id, .. }) => id.name.clone(),
+                ast::Entry::Term(ast::Term { ref id, .. }) => id.name.clone(),
                 _ => continue,
             };
 
             match entry {
                 ast::Entry::Message(message) => {
                     self.messages.insert(id, message);
+                }
+                ast::Entry::Term(term) => {
+                    self.terms.insert(id, term);
                 }
                 _ => continue,
             };

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -6,6 +6,7 @@ pub struct Resource {
 #[derive(Debug, PartialEq)]
 pub enum Entry {
     Message(Message),
+    Term(Term),
     Comment(Comment),
     Junk { content: String },
 }
@@ -19,6 +20,14 @@ pub struct Message {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct Term {
+    pub id: Identifier,
+    pub value: Pattern,
+    pub attributes: Option<Vec<Attribute>>,
+    pub comment: Option<Comment>,
+}
+
+#[derive(Debug, PartialEq)]
 pub struct Pattern {
     pub elements: Vec<PatternElement>,
 }
@@ -26,12 +35,7 @@ pub struct Pattern {
 #[derive(Debug, PartialEq)]
 pub enum PatternElement {
     TextElement(String),
-    Placeable(Placeable),
-}
-
-#[derive(Debug, PartialEq)]
-pub struct Placeable {
-    pub expression: Expression,
+    Placeable(Expression),
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/syntax/errors/list.rs
+++ b/src/syntax/errors/list.rs
@@ -16,27 +16,24 @@ pub struct ErrorInfo {
 pub enum ErrorKind {
     Generic,
     ExpectedEntry,
-    ExpectedToken {
-        token: char,
-    },
-    ExpectedCharRange {
-        range: String,
-    },
-    ExpectedField {
-        field: String,
-    },
-    MissingField {
-        entry_id: String,
-        fields: Vec<&'static str>,
-    },
-    MissingDefaultVariant,
-    MissingVariants,
+    ExpectedToken { token: char },
+    ExpectedCharRange { range: String },
+    ExpectedMessageField { entry_id: String },
+    ExpectedTermField { entry_id: String },
     ForbiddenWhitespace,
     ForbiddenCallee,
     ForbiddenKey,
-    ForbiddenPrivateAttributeExpression,
-    ForbiddenPublicAttributeExpression,
-    ForbiddenVariantExpression,
+    MissingDefaultVariant,
+    MissingVariants,
+    MissingValue,
+    MissingVariantKey,
+    MissingLiteral,
+    MultipleDefaultVariants,
+    MessageReferenceAsSelector,
+    VariantAsSelector,
+    MessageAttributeAsSelector,
+    TermAttributeAsSelector,
+    UnterminatedStringExpression,
 }
 
 pub fn get_error_desc(err: &ErrorKind) -> (&'static str, String, &'static str) {
@@ -45,7 +42,7 @@ pub fn get_error_desc(err: &ErrorKind) -> (&'static str, String, &'static str) {
         ErrorKind::ExpectedEntry => (
             "E0002",
             "Expected an entry start".to_owned(),
-            "Expected one of ('a'...'Z' | '_' | '[[' | '#') here",
+            "Expected one of ('a'...'Z' | '_' | #') here",
         ),
         ErrorKind::ExpectedToken { token } => ("E0003", format!("expected token `{}`", token), ""),
         ErrorKind::ExpectedCharRange { ref range } => (
@@ -53,23 +50,19 @@ pub fn get_error_desc(err: &ErrorKind) -> (&'static str, String, &'static str) {
             format!("Expected a character from range ({})", range),
             "",
         ),
-        ErrorKind::MissingField {
-            ref entry_id,
-            ref fields,
-        } => {
-            let list = fields.join(", ");
-            (
-                "E0005",
-                format!(
-                    "Expected entry `{}` to have one of the fields: {}",
-                    entry_id, list
-                ),
-                "",
-            )
-        }
-        ErrorKind::ExpectedField { ref field } => {
-            ("E0006", format!("Expected field: {}", field), "")
-        }
+        ErrorKind::ExpectedMessageField { ref entry_id } => (
+            "E0005",
+            format!(
+                "Expected message `{}` to have a value or attributes",
+                entry_id
+            ),
+            "",
+        ),
+        ErrorKind::ExpectedTermField { ref entry_id } => (
+            "E0006",
+            format!("Expected term `{}` to have a value", entry_id),
+            "",
+        ),
         ErrorKind::ForbiddenWhitespace => (
             "E0007",
             "Keyword cannot end with a whitespace".to_owned(),
@@ -95,20 +88,36 @@ pub fn get_error_desc(err: &ErrorKind) -> (&'static str, String, &'static str) {
             "Expected at least one variant after \"->\".".to_owned(),
             "",
         ),
-        ErrorKind::ForbiddenPrivateAttributeExpression => (
-            "E0012",
-            "Attributes of private messages cannot be used as placeables.".to_owned(),
+        ErrorKind::MissingValue => ("E0012", "Expected value".to_owned(), ""),
+        ErrorKind::MissingVariantKey => ("E0013", "Expected variant key".to_owned(), ""),
+        ErrorKind::MissingLiteral => ("E0014", "Expected literal".to_owned(), ""),
+        ErrorKind::MultipleDefaultVariants => (
+            "E0015",
+            "Only one variant can be marked as default (*)".to_owned(),
             "",
         ),
-        ErrorKind::ForbiddenPublicAttributeExpression => (
-            "E0013",
-            "Attributes of public messages cannot be used as selectors.".to_owned(),
+        ErrorKind::MessageReferenceAsSelector => (
+            "E0016",
+            "Message references cannot be used as selectors".to_owned(),
             "",
         ),
-        ErrorKind::ForbiddenVariantExpression => (
-            "E0014",
-            "Variants cannot be used as selectors.".to_owned(),
+        ErrorKind::VariantAsSelector => (
+            "E0017",
+            "Variants cannot be used as selectors".to_owned(),
             "",
         ),
+        ErrorKind::MessageAttributeAsSelector => (
+            "E0018",
+            "Attributes of messages cannot be used as selectors.".to_owned(),
+            "",
+        ),
+        ErrorKind::TermAttributeAsSelector => (
+            "E0019",
+            "Attributes of terms cannot be used as selectors.".to_owned(),
+            "",
+        ),
+        ErrorKind::UnterminatedStringExpression => {
+            ("E0020", "Underminated string expression".to_owned(), "")
+        }
     }
 }

--- a/src/syntax/ftlstream.rs
+++ b/src/syntax/ftlstream.rs
@@ -4,10 +4,13 @@ use super::stream::ParserStream;
 use super::parser::Result;
 
 pub trait FTLParserStream<I> {
-    fn peek_line_ws(&mut self);
-    fn skip_ws_lines(&mut self);
-    fn skip_line_ws(&mut self);
+    fn skip_inline_ws(&mut self);
+    fn peek_inline_ws(&mut self);
+    fn skip_blank_lines(&mut self);
+    fn peek_blank_lines(&mut self);
+    fn skip_indent(&mut self);
     fn expect_char(&mut self, ch: char) -> Result<()>;
+    fn expect_indent(&mut self) -> Result<()>;
     fn take_char_if(&mut self, ch: char) -> bool;
 
     fn take_char<F>(&mut self, f: F) -> Option<char>
@@ -15,50 +18,79 @@ pub trait FTLParserStream<I> {
         F: Fn(char) -> bool;
 
     fn is_char_id_start(&mut self, ch: Option<char>) -> bool;
-    fn is_message_id_start(&mut self) -> bool;
-    fn is_peek_next_line_indented(&mut self) -> bool;
+    fn is_entry_id_start(&mut self) -> bool;
+    fn is_number_start(&mut self) -> bool;
+    fn is_char_pattern_continuation(&self, ch: Option<char>) -> bool;
+    fn is_peek_pattern_start(&mut self) -> bool;
+    fn is_peek_next_line_zero_four_style_comment(&mut self) -> bool;
+    fn is_peek_next_line_comment(&mut self, level: i8) -> bool;
     fn is_peek_next_line_variant_start(&mut self) -> bool;
     fn is_peek_next_line_attribute_start(&mut self) -> bool;
-    fn is_peek_next_line_pattern(&mut self) -> bool;
+    fn is_peek_next_line_pattern_start(&mut self) -> bool;
     fn skip_to_next_entry_start(&mut self);
     fn take_id_start(&mut self, allow_private: bool) -> Result<char>;
     fn take_id_char(&mut self) -> Option<char>;
-    fn take_symb_char(&mut self) -> Option<char>;
+    fn take_variant_name_char(&mut self) -> Option<char>;
     fn take_digit(&mut self) -> Option<char>;
 }
+
+static INLINE_WS: [char; 2] = [' ', '\t'];
+static SPECIAL_LINE_START_CHARS: [char; 4] = ['}', '.', '[', '*'];
 
 impl<I> FTLParserStream<I> for ParserStream<I>
 where
     I: Iterator<Item = char>,
 {
-    fn peek_line_ws(&mut self) {
-        while let Some(ch) = self.current_peek() {
-            if ch != ' ' && ch != '\t' {
+    fn skip_inline_ws(&mut self) {
+        while let Some(ch) = self.ch {
+            if !INLINE_WS.contains(&ch) {
                 break;
             }
+            self.next();
+        }
+    }
 
+    fn peek_inline_ws(&mut self) {
+        while let Some(ch) = self.current_peek() {
+            if !INLINE_WS.contains(&ch) {
+                break;
+            }
             self.peek();
         }
     }
 
-    fn skip_ws_lines(&mut self) {
+    fn skip_blank_lines(&mut self) {
         loop {
-            self.peek_line_ws();
+            self.peek_inline_ws();
 
             if self.current_peek() == Some('\n') {
                 self.skip_to_peek();
                 self.next();
             } else {
-                self.reset_peek();
+                self.reset_peek(None);
                 break;
             }
         }
     }
 
-    fn skip_line_ws(&mut self) {
-        while self.ch == Some(' ') || self.ch == Some('\t') {
-            self.next();
+    fn peek_blank_lines(&mut self) {
+        loop {
+            let line_start = self.get_peek_index();
+
+            self.peek_inline_ws();
+
+            if self.current_peek_is('\n') {
+                self.peek();
+            } else {
+                self.reset_peek(Some(line_start));
+                break;
+            }
         }
+    }
+
+    fn skip_indent(&mut self) {
+        self.skip_blank_lines();
+        self.skip_inline_ws();
     }
 
     fn expect_char(&mut self, ch: char) -> Result<()> {
@@ -67,7 +99,20 @@ where
             return Ok(());
         }
 
+        if self.ch == Some('\n') {
+            // Unicode Character 'SYMBOL FOR NEWLINE' (U+2424)
+            return error!(ErrorKind::ExpectedToken { token: '\u{2424}' });
+        }
+
         error!(ErrorKind::ExpectedToken { token: ch })
+    }
+
+    fn expect_indent(&mut self) -> Result<()> {
+        self.expect_char('\n')?;
+        self.skip_blank_lines();
+        self.expect_char(' ')?;
+        self.skip_inline_ws();
+        Ok(())
     }
 
     fn take_char_if(&mut self, ch: char) -> bool {
@@ -99,29 +144,94 @@ where
         }
     }
 
-    fn is_message_id_start(&mut self) -> bool {
+    fn is_entry_id_start(&mut self) -> bool {
         if let Some('-') = self.ch {
             self.peek();
         }
         let ch = self.current_peek();
         let is_id = self.is_char_id_start(ch);
-        self.reset_peek();
+        self.reset_peek(None);
         is_id
     }
 
-    fn is_peek_next_line_indented(&mut self) -> bool {
+    fn is_number_start(&mut self) -> bool {
+        if let Some('-') = self.ch {
+            self.peek();
+        }
+        let ch = self.current_peek();
+        let is_digit = match ch {
+            Some('0'...'9') => true,
+            _ => false,
+        };
+        self.reset_peek(None);
+        is_digit
+    }
+
+    fn is_char_pattern_continuation(&self, ch: Option<char>) -> bool {
+        match ch {
+            Some(ch) => !SPECIAL_LINE_START_CHARS.contains(&ch),
+            _ => false,
+        }
+    }
+
+    fn is_peek_pattern_start(&mut self) -> bool {
+        self.peek_inline_ws();
+
+        if let Some(ch) = self.current_peek() {
+            if ch != '\n' {
+                return true;
+            }
+        }
+
+        return self.is_peek_next_line_pattern_start();
+    }
+
+    fn is_peek_next_line_zero_four_style_comment(&mut self) -> bool {
         if !self.current_peek_is('\n') {
             return false;
         }
         self.peek();
 
-        if self.current_peek_is(' ') {
-            self.reset_peek();
-            return true;
+        if self.current_peek_is('/') {
+            self.peek();
+            if self.current_peek_is('/') {
+                self.reset_peek(None);
+                return true;
+            }
+        }
+        self.reset_peek(None);
+        return false;
+    }
+
+    fn is_peek_next_line_comment(&mut self, level: i8) -> bool {
+        if !self.current_peek_is('\n') {
+            return false;
         }
 
-        self.reset_peek();
-        false
+        let mut i = 0;
+
+        while i <= level && (level == -1 && i < 3) {
+            self.peek();
+            if !self.current_peek_is('#') {
+                if i != level && level != -1 {
+                    self.reset_peek(None);
+                    return false;
+                }
+                break;
+            }
+            i += 1;
+        }
+
+        self.peek();
+
+        if let Some(ch) = self.current_peek() {
+            if [' ', '\n'].contains(&ch) {
+                self.reset_peek(None);
+                return true;
+            }
+        }
+        self.reset_peek(None);
+        return false;
     }
 
     fn is_peek_next_line_variant_start(&mut self) -> bool {
@@ -130,12 +240,14 @@ where
         }
         self.peek();
 
+        self.peek_blank_lines();
+
         let ptr = self.get_peek_index();
 
-        self.peek_line_ws();
+        self.peek_inline_ws();
 
         if self.get_peek_index() - ptr == 0 {
-            self.reset_peek();
+            self.reset_peek(None);
             return false;
         }
 
@@ -144,10 +256,10 @@ where
         }
 
         if self.current_peek_is('[') && !self.peek_char_is('[') {
-            self.reset_peek();
+            self.reset_peek(None);
             return true;
         }
-        self.reset_peek();
+        self.reset_peek(None);
         false
     }
 
@@ -157,78 +269,89 @@ where
         }
         self.peek();
 
+        self.peek_blank_lines();
+
         let ptr = self.get_peek_index();
 
-        self.peek_line_ws();
+        self.peek_inline_ws();
 
         if self.get_peek_index() - ptr == 0 {
-            self.reset_peek();
+            self.reset_peek(None);
             return false;
         }
 
         if self.current_peek_is('.') {
-            self.reset_peek();
+            self.reset_peek(None);
             return true;
         }
 
-        self.reset_peek();
+        self.reset_peek(None);
         false
     }
 
-    fn is_peek_next_line_pattern(&mut self) -> bool {
+    fn is_peek_next_line_pattern_start(&mut self) -> bool {
         if !self.current_peek_is('\n') {
             return false;
         }
         self.peek();
 
+        self.peek_blank_lines();
+
         let ptr = self.get_peek_index();
 
-        self.peek_line_ws();
+        self.peek_inline_ws();
 
         if self.get_peek_index() - ptr == 0 {
-            self.reset_peek();
+            self.reset_peek(None);
             return false;
         }
 
-        if self.current_peek_is('}') || self.current_peek_is('.') || self.current_peek_is('[')
-            || self.current_peek_is('*')
-        {
-            self.reset_peek();
+        if !self.is_char_pattern_continuation(self.current_peek()) {
+            self.reset_peek(None);
             return false;
         }
 
-        self.reset_peek();
+        self.reset_peek(None);
         true
     }
 
     fn skip_to_next_entry_start(&mut self) {
         while let Some(_) = self.next() {
-            if self.current_is('\n') && !self.peek_char_is('\n')
-                && (self.next() == None || self.is_message_id_start() || self.current_is('#'))
-            {
-                break;
+            if self.current_is('\n') && !self.peek_char_is('\n') {
+                self.next();
+
+                if self.ch.is_none() || self.is_entry_id_start() || self.current_is('#')
+                    || (self.current_is('/') && self.peek_char_is('/'))
+                    || (self.current_is('[') && self.peek_char_is('['))
+                {
+                    break;
+                }
             }
         }
     }
 
-    fn take_id_start(&mut self, allow_private: bool) -> Result<char> {
-        let closure = |x| match x {
-            'a'...'z' | 'A'...'Z' => true,
-            '-' => allow_private,
-            _ => false,
-        };
-
-        if let Some(ch) = self.take_char(closure) {
-            Ok(ch)
-        } else if allow_private {
-            error!(ErrorKind::ExpectedCharRange {
-                range: String::from("'a'...'z' | 'A'...'Z'"),
-            })
-        } else {
-            error!(ErrorKind::ExpectedCharRange {
-                range: String::from("'a'...'z' | 'A'...'Z' | '-'"),
-            })
+    fn take_id_start(&mut self, allow_term: bool) -> Result<char> {
+        if allow_term && self.current_is('-') {
+            self.next();
+            return Ok('-');
         }
+
+        if let Some(ch) = self.ch {
+            if self.is_char_id_start(Some(ch)) {
+                let ret = self.ch.unwrap();
+                self.next();
+                return Ok(ret);
+            }
+        }
+
+        let allowed_range = if allow_term {
+            "'a'...'z' | 'A'...'Z' | '-'"
+        } else {
+            "'a'...'z' | 'A'...'Z'"
+        };
+        error!(ErrorKind::ExpectedCharRange {
+            range: String::from(allowed_range),
+        })
     }
 
     fn take_id_char(&mut self) -> Option<char> {
@@ -243,7 +366,7 @@ where
         }
     }
 
-    fn take_symb_char(&mut self) -> Option<char> {
+    fn take_variant_name_char(&mut self) -> Option<char> {
         let closure = |x| match x {
             'a'...'z' | 'A'...'Z' | '0'...'9' | '_' | '-' | ' ' => true,
             _ => false,

--- a/src/syntax/stream.rs
+++ b/src/syntax/stream.rs
@@ -102,9 +102,19 @@ impl<I: Iterator<Item = char>> ParserStream<I> {
         ret
     }
 
-    pub fn reset_peek(&mut self) {
-        self.peek_index = self.index;
-        self.peek_end = self.iter_end;
+    pub fn reset_peek(&mut self, pos: Option<usize>) {
+        match pos {
+            Some(pos) => {
+                if pos < self.peek_index {
+                    self.peek_end = false
+                }
+                self.peek_index = pos
+            }
+            None => {
+                self.peek_index = self.index;
+                self.peek_end = self.iter_end;
+            }
+        }
     }
 
     pub fn skip_to_peek(&mut self) {

--- a/tests/fixtures/parser/ftl/01-basic-errors01.ftl
+++ b/tests/fixtures/parser/ftl/01-basic-errors01.ftl
@@ -21,6 +21,3 @@ id
 -1 = Foo
 
 19 = Foo2
-
-key13 = Single Value
-  Multi Value

--- a/tests/fixtures/parser/ftl/02-multiline01.ftl
+++ b/tests/fixtures/parser/ftl/02-multiline01.ftl
@@ -1,14 +1,14 @@
 key1 =
-     | This is a new line
+    This is a new line
 
-key4=
- | <p>
- |   So
- |     Many
- |   Lines
- | </p>
+key4 =
+  <p>
+    So
+      Many
+    Lines
+  </p>
 
 key5 =        
- |<p>
- | Foo
- |</p>
+ <p>
+  Foo
+ </p>

--- a/tests/fixtures/parser/ftl/05-variants.ftl
+++ b/tests/fixtures/parser/ftl/05-variants.ftl
@@ -9,14 +9,14 @@ key3 = {
     [feminine] Variant for feminine
   }
 
-key4
+key4 =
  .aria-label = Test
 
-key5
+key5 =
  .aria-label = Test
  .loop = Foo
 
-key5
+key5 =
  .m = Foo
 
 ## section

--- a/tests/resolve_attribute_expression.rs
+++ b/tests/resolve_attribute_expression.rs
@@ -10,7 +10,7 @@ fn attribute_expression() {
         "
 foo = Foo
     .attr = Foo Attr
-bar
+bar =
     .attr = Bar Attr
 
 use-foo = { foo }

--- a/tests/resolve_message_reference.rs
+++ b/tests/resolve_message_reference.rs
@@ -18,6 +18,21 @@ bar = { foo } Bar
 }
 
 #[test]
+fn term_reference() {
+    let mut ctx = MessageContext::new(&["x-testing"]);
+
+    ctx.add_messages(
+        "
+-foo = Foo
+bar = { -foo } Bar
+",
+    );
+
+    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    assert_eq!(value, Some("Foo Bar".to_string()));
+}
+
+#[test]
 fn message_reference_nested() {
     let mut ctx = MessageContext::new(&["x-testing"]);
 

--- a/tests/resolve_select_expression.rs
+++ b/tests/resolve_select_expression.rs
@@ -245,15 +245,8 @@ fn select_expression_message_selector() {
 
     ctx.add_messages(
         "
-foo = Foo
 -bar = Bar
     .attr = attr val
-
-use-foo =
-    { foo ->
-        [Foo 2] Foo
-       *[other] Other
-    }
 
 use-bar =
     { -bar.attr ->
@@ -262,10 +255,6 @@ use-bar =
     }
 ",
     );
-
-    let value = ctx.get_message("use-foo")
-        .and_then(|msg| ctx.format(msg, None));
-    assert_eq!(value, Some("Other".to_string()));
 
     let value = ctx.get_message("use-bar")
         .and_then(|msg| ctx.format(msg, None));

--- a/tests/resolve_variant_expression.rs
+++ b/tests/resolve_variant_expression.rs
@@ -8,22 +8,23 @@ fn variant_expression() {
 
     ctx.add_messages(
         "
-foo = Foo
-bar =
+-foo = Foo
+-bar =
     {
        *[nominative] Bar
         [genitive] Bar's
     }
+bar = { -bar }
 
-use-foo = { foo }
-use-foo-missing = { foo[missing] }
+use-foo = { -foo }
+use-foo-missing = { -foo[missing] }
 
-use-bar = { bar }
-use-bar-nominative = { bar[nominative] }
-use-bar-genitive = { bar[genitive] }
-use-bar-missing = { bar[missing] }
+use-bar = { -bar }
+use-bar-nominative = { -bar[nominative] }
+use-bar-genitive = { -bar[genitive] }
+use-bar-missing = { -bar[missing] }
 
-missing-missing = { missing[missing] }
+missing-missing = { -missing[missing] }
 ",
     );
 

--- a/tests/syntax/errors.rs
+++ b/tests/syntax/errors.rs
@@ -78,13 +78,7 @@ fn just_id_errors() {
 
             let error1 = &errors[0];
 
-            assert_eq!(
-                ErrorKind::MissingField {
-                    entry_id: "key".to_owned(),
-                    fields: vec!["Value", "Attribute"],
-                },
-                error1.kind
-            );
+            assert_eq!(ErrorKind::ExpectedToken { token: '\u{2424}' }, error1.kind);
 
             assert_eq!(
                 Some(ErrorInfo {
@@ -110,13 +104,7 @@ fn no_equal_sign_errors() {
 
             let error1 = &errors[0];
 
-            assert_eq!(
-                ErrorKind::MissingField {
-                    entry_id: "key".to_owned(),
-                    fields: vec!["Value", "Attribute"],
-                },
-                error1.kind
-            );
+            assert_eq!(ErrorKind::ExpectedToken { token: '=' }, error1.kind);
 
             assert_eq!(
                 Some(ErrorInfo {
@@ -144,7 +132,7 @@ fn wrong_char_in_id_errors() {
 
             assert_eq!(
                 ErrorKind::ExpectedCharRange {
-                    range: "'a'...'z' | 'A'...'Z' | '-'".to_owned(),
+                    range: "'a'...'z' | 'A'...'Z'".to_owned(),
                 },
                 error1.kind
             );
@@ -173,7 +161,7 @@ fn missing_trait_value_errors() {
 
             let error1 = &errors[0];
 
-            assert_eq!(ErrorKind::ExpectedToken { token: '=' }, error1.kind);
+            assert_eq!(ErrorKind::ExpectedToken { token: '\u{2424}' }, error1.kind);
 
             assert_eq!(
                 Some(ErrorInfo {
@@ -199,13 +187,7 @@ fn message_missing_fields_errors() {
 
             let error1 = &errors[0];
 
-            assert_eq!(
-                ErrorKind::MissingField {
-                    entry_id: "key".to_owned(),
-                    fields: vec!["Value", "Attribute"],
-                },
-                error1.kind
-            );
+            assert_eq!(ErrorKind::ExpectedToken { token: '\u{2424}' }, error1.kind);
 
             assert_eq!(
                 Some(ErrorInfo {
@@ -253,7 +235,7 @@ fn private_errors() {
 
             assert_eq!(
                 ErrorKind::ExpectedCharRange {
-                    range: "'a'...'z' | 'A'...'Z' | '-'".to_owned(),
+                    range: "'a'...'z' | 'A'...'Z'".to_owned(),
                 },
                 error2.kind
             );
@@ -270,7 +252,7 @@ fn private_errors() {
 
             let error3 = &errors[2];
 
-            assert_eq!(ErrorKind::ForbiddenPrivateAttributeExpression, error3.kind);
+            assert_eq!(ErrorKind::TermAttributeAsSelector, error3.kind);
 
             assert_eq!(
                 Some(ErrorInfo {

--- a/tests/syntax/stream.rs
+++ b/tests/syntax/stream.rs
@@ -133,7 +133,7 @@ fn reset_peek() {
     ps.next();
     ps.peek();
     ps.peek();
-    ps.reset_peek();
+    ps.reset_peek(None);
 
     assert_eq!(Some('b'), ps.current());
     assert_eq!(Some('b'), ps.current_peek());
@@ -150,7 +150,7 @@ fn reset_peek() {
     ps.peek();
     ps.peek();
     ps.peek();
-    ps.reset_peek();
+    ps.reset_peek(None);
 
     assert_eq!(Some('b'), ps.current());
     assert_eq!(Some('b'), ps.current_peek());


### PR DESCRIPTION
Aligns the parser with python_fluent as much as possible. Lots of pythonisms that I'd like to work on after landing this.
Also, had to disable two tests due to the unfortunate messages/terms split. I'd like to brainstorm solutions outside of this patch as well :)