### PR TITLE
Update ansi-term dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["localization", "internationalization"]
 
 [dependencies]
 getopts = "0.2.17"
-ansi_term = "0.10.2"
+ansi_term = "0.11"
 fluent-locale = "0.3.1"
 
 [dev-dependencies]


### PR DESCRIPTION
This allows the docs to build without warnings.