### PR TITLE
Support custom functions in MessageContext #25

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -3,12 +3,12 @@
 extern crate fluent;
 extern crate test;
 
+use fluent::context::MessageContext;
+use fluent::syntax::{ast, parse};
+use std::fs::File;
 use std::io;
 use std::io::Read;
-use std::fs::File;
 use test::Bencher;
-use fluent::syntax::{ast, parse};
-use fluent::context::MessageContext;
 
 fn read_file(path: &str) -> Result<String, io::Error> {
     let mut f = try!(File::open(path));

--- a/examples/external_arguments.rs
+++ b/examples/external_arguments.rs
@@ -18,14 +18,16 @@ unread-emails = You have { $emailCount } unread emails
     let mut args = HashMap::new();
     args.insert("name", FluentValue::from("John"));
 
-    match ctx.get_message("hello-world")
+    match ctx
+        .get_message("hello-world")
         .and_then(|msg| ctx.format(msg, Some(&args)))
     {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }
 
-    match ctx.get_message("ref")
+    match ctx
+        .get_message("ref")
         .and_then(|msg| ctx.format(msg, Some(&args)))
     {
         Some(value) => println!("{}", value),
@@ -35,7 +37,8 @@ unread-emails = You have { $emailCount } unread emails
     let mut args = HashMap::new();
     args.insert("emailCount", FluentValue::from(5));
 
-    match ctx.get_message("unread-emails")
+    match ctx
+        .get_message("unread-emails")
         .and_then(|msg| ctx.format(msg, Some(&args)))
     {
         Some(value) => println!("{}", value),

--- a/examples/functions.rs
+++ b/examples/functions.rs
@@ -1,7 +1,7 @@
 extern crate fluent;
 
-use fluent::MessageContext;
 use fluent::types::FluentValue;
+use fluent::MessageContext;
 
 fn main() {
     let mut ctx = MessageContext::new(&["en-US"]);
@@ -38,18 +38,21 @@ fn main() {
     ctx.add_messages("meaning-of-life = { MEANING_OF_LIFE(42) }");
     ctx.add_messages("all-your-base = { BASE_OWNERSHIP(hello, ownership: \"us\") }");
 
-    let value = ctx.get_message("hello-world")
+    let value = ctx
+        .get_message("hello-world")
         .and_then(|message| ctx.format(message, None));
     assert_eq!(value, Some("Hey there! I'm a function!".to_string()));
 
-    let value = ctx.get_message("meaning-of-life")
+    let value = ctx
+        .get_message("meaning-of-life")
         .and_then(|message| ctx.format(message, None));
     assert_eq!(
         value,
         Some("The answer to life, the universe, and everything".to_string())
     );
 
-    let value = ctx.get_message("all-your-base")
+    let value = ctx
+        .get_message("all-your-base")
         .and_then(|message| ctx.format(message, None));
     assert_eq!(value, Some("All your base belong to us".to_string()));
 }

--- a/examples/functions.rs
+++ b/examples/functions.rs
@@ -7,41 +7,32 @@ fn main() {
     let mut ctx = MessageContext::new(&["en-US"]);
 
     // Test for a simple function that returns a string
-    ctx.add_function(
-        "HELLO",
-        Box::new(|_args, _named_args| {
-            return Some("I'm a function!".into());
-        }),
-    );
+    ctx.add_function("HELLO", |_args, _named_args| {
+        return Some("I'm a function!".into());
+    });
 
-    // Test for a function that accepts unnamed arguments
-    ctx.add_function(
-        "MEANING_OF_LIFE",
-        Box::new(|args, _named_args| {
-            if args.len() > 0 {
-                if args[0] == FluentValue::Number(42.0) {
-                    return Some("The answer to life, the universe, and everything".into());
-                }
+    // Test for a function that accepts unnamed positional arguments
+    ctx.add_function("MEANING_OF_LIFE", |args, _named_args| {
+        if let Some(arg0) = args.get(0) {
+            if *arg0 == Some(FluentValue::Number(42.0)) {
+                return Some("The answer to life, the universe, and everything".into());
             }
+        }
 
-            None
-        }),
-    );
+        None
+    });
 
     // Test for a function that accepts named arguments
-    ctx.add_function(
-        "BASE_OWNERSHIP",
-        Box::new(|_args, named_args| {
-            let ownership = named_args.get("ownership").unwrap();
+    ctx.add_function("BASE_OWNERSHIP", |_args, named_args| {
+        let ownership = named_args.get("ownership").unwrap();
 
-            return match ownership {
-                &FluentValue::String(ref string) => {
-                    Some(format!("All your base belong to {}", string).into())
-                }
-                _ => None,
-            };
-        }),
-    );
+        return match ownership {
+            &FluentValue::String(ref string) => {
+                Some(format!("All your base belong to {}", string).into())
+            }
+            _ => None,
+        };
+    });
 
     ctx.add_messages("hello-world = Hey there! { HELLO() }");
     ctx.add_messages("meaning-of-life = { MEANING_OF_LIFE(42) }");

--- a/examples/functions.rs
+++ b/examples/functions.rs
@@ -1,0 +1,70 @@
+extern crate fluent;
+
+use fluent::MessageContext;
+use fluent::types::FluentValue;
+
+fn main() {
+    let mut ctx = MessageContext::new(&["en-US"]);
+
+    // Test for a simple function that returns a string
+    ctx.add_function(
+        "HELLO",
+        Box::new(|_args, _named_args| {
+            return Some("I'm a function!".to_string().into());
+        }),
+    );
+
+    // Test for a function that accepts unnamed arguments
+    ctx.add_function(
+        "MEANING_OF_LIFE",
+        Box::new(|args, _named_args| {
+            if args.len() > 0 {
+                if args[0] == FluentValue::Number(42.0) {
+                    return Some(
+                        "The answer to life, the universe, and everything"
+                            .to_string()
+                            .into(),
+                    );
+                }
+            }
+
+            None
+        }),
+    );
+
+    // Test for a function that accepts named arguments
+    ctx.add_function(
+        "BASE_OWNERSHIP",
+        Box::new(|_args, named_args| {
+            let ownership = named_args.get("ownership").unwrap();
+
+            return match ownership {
+                FluentValue::String(string) => Some(
+                    format!("All your base belong to {}", string)
+                        .to_string()
+                        .into(),
+                ),
+                _ => None,
+            };
+        }),
+    );
+
+    ctx.add_messages("hello-world = Hey there! { HELLO() }");
+    ctx.add_messages("meaning-of-life = { MEANING_OF_LIFE(42) }");
+    ctx.add_messages("all-your-base = { BASE_OWNERSHIP(hello, ownership: \"us\") }");
+
+    let value = ctx.get_message("hello-world")
+        .and_then(|message| ctx.format(message, None));
+    assert_eq!(value, Some("Hey there! I'm a function!".to_string()));
+
+    let value = ctx.get_message("meaning-of-life")
+        .and_then(|message| ctx.format(message, None));
+    assert_eq!(
+        value,
+        Some("The answer to life, the universe, and everything".to_string())
+    );
+
+    let value = ctx.get_message("all-your-base")
+        .and_then(|message| ctx.format(message, None));
+    assert_eq!(value, Some("All your base belong to us".to_string()));
+}

--- a/examples/functions.rs
+++ b/examples/functions.rs
@@ -10,7 +10,7 @@ fn main() {
     ctx.add_function(
         "HELLO",
         Box::new(|_args, _named_args| {
-            return Some("I'm a function!".to_string().into());
+            return Some("I'm a function!".into());
         }),
     );
 
@@ -20,11 +20,7 @@ fn main() {
         Box::new(|args, _named_args| {
             if args.len() > 0 {
                 if args[0] == FluentValue::Number(42.0) {
-                    return Some(
-                        "The answer to life, the universe, and everything"
-                            .to_string()
-                            .into(),
-                    );
+                    return Some("The answer to life, the universe, and everything".into());
                 }
             }
 
@@ -39,11 +35,9 @@ fn main() {
             let ownership = named_args.get("ownership").unwrap();
 
             return match ownership {
-                FluentValue::String(string) => Some(
-                    format!("All your base belong to {}", string)
-                        .to_string()
-                        .into(),
-                ),
+                FluentValue::String(string) => {
+                    Some(format!("All your base belong to {}", string).into())
+                }
                 _ => None,
             };
         }),

--- a/examples/functions.rs
+++ b/examples/functions.rs
@@ -35,7 +35,7 @@ fn main() {
             let ownership = named_args.get("ownership").unwrap();
 
             return match ownership {
-                FluentValue::String(string) => {
+                &FluentValue::String(ref string) => {
                     Some(format!("All your base belong to {}", string).into())
                 }
                 _ => None,

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -6,7 +6,8 @@ fn main() {
     let mut ctx = MessageContext::new(&["en-US"]);
     ctx.add_messages("hello-world = Hello, world!");
 
-    let value = ctx.get_message("hello-world")
+    let value = ctx
+        .get_message("hello-world")
         .and_then(|message| ctx.format(message, None));
 
     assert_eq!(value, Some("Hello, world!".to_string()));

--- a/examples/message_reference.rs
+++ b/examples/message_reference.rs
@@ -13,14 +13,16 @@ bazbar = { baz } Bar
 ",
     );
 
-    match ctx.get_message("foobar")
+    match ctx
+        .get_message("foobar")
         .and_then(|msg| ctx.format(msg, None))
     {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }
 
-    match ctx.get_message("bazbar")
+    match ctx
+        .get_message("bazbar")
         .and_then(|msg| ctx.format(msg, None))
     {
         Some(value) => println!("{}", value),

--- a/examples/selector.rs
+++ b/examples/selector.rs
@@ -21,7 +21,8 @@ hello-world2 = Hello { $name ->
 ",
     );
 
-    match ctx.get_message("hello-world")
+    match ctx
+        .get_message("hello-world")
         .and_then(|msg| ctx.format(msg, None))
     {
         Some(value) => println!("{}", value),
@@ -31,7 +32,8 @@ hello-world2 = Hello { $name ->
     let mut args = HashMap::new();
     args.insert("name", FluentValue::from("moon"));
 
-    match ctx.get_message("hello-world2")
+    match ctx
+        .get_message("hello-world2")
         .and_then(|msg| ctx.format(msg, Some(&args)))
     {
         Some(value) => println!("{}", value),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -12,14 +12,16 @@ key2 = Value 2
 ",
     );
 
-    match ctx.get_message("key1")
+    match ctx
+        .get_message("key1")
         .and_then(|msg| ctx.format(msg, None))
     {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }
 
-    match ctx.get_message("key2")
+    match ctx
+        .get_message("key2")
         .and_then(|msg| ctx.format(msg, None))
     {
         Some(value) => println!("{}", value),

--- a/src/bin/parser.rs
+++ b/src/bin/parser.rs
@@ -1,17 +1,17 @@
 extern crate fluent;
 extern crate getopts;
 
-use std::fs::File;
-use std::io::Read;
-use std::io;
 use std::env;
+use std::fs::File;
+use std::io;
+use std::io::Read;
 
 use getopts::Options;
 
-use fluent::syntax::parser::parse;
 use fluent::syntax::ast::Resource;
 use fluent::syntax::errors::display::annotate_slice;
 use fluent::syntax::errors::display::Item;
+use fluent::syntax::parser::parse;
 
 fn read_file(path: &str) -> Result<String, io::Error> {
     let mut f = try!(File::open(path));

--- a/src/context.rs
+++ b/src/context.rs
@@ -44,7 +44,7 @@ pub struct MessageContext<'ctx> {
     terms: HashMap<String, ast::Term>,
     functions: HashMap<
         String,
-        Box<Fn(&[FluentValue], &HashMap<String, FluentValue>) -> Option<FluentValue>>,
+        Box<Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>>,
     >,
 }
 
@@ -70,25 +70,21 @@ impl<'ctx> MessageContext<'ctx> {
         self.terms.get(id)
     }
 
-    pub fn add_function(
-        &mut self,
-        id: &str,
-        func: Box<Fn(&[FluentValue], &HashMap<String, FluentValue>) -> Option<FluentValue>>,
-    ) {
-        self.functions.insert(id.to_string(), func);
+    pub fn add_function<F>(&mut self, id: &str, func: F)
+    where
+        F: 'static
+            + Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>,
+    {
+        self.functions.insert(id.to_string(), Box::new(func));
     }
 
-    pub fn exec_function(
+    pub fn get_function(
         &self,
         id: &str,
-        args: &[FluentValue],
-        named_args: &HashMap<String, FluentValue>,
-    ) -> Option<FluentValue> {
-        if let Some(func) = self.functions.get(id) {
-            func(args, named_args)
-        } else {
-            None
-        }
+    ) -> Option<
+        &Box<Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>>,
+    > {
+        self.functions.get(id)
     }
 
     pub fn add_messages(&mut self, source: &str) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,10 +6,10 @@
 
 use std::collections::HashMap;
 
+use super::resolve::{Env, ResolveValue};
 use super::syntax::ast;
 use super::syntax::parse;
 use super::types::FluentValue;
-use super::resolve::{Env, ResolveValue};
 
 /// `MessageContext` is a collection of localization messages which are meant to be used together
 /// in a single view, widget or any other UI abstraction.
@@ -44,7 +44,9 @@ pub struct MessageContext<'ctx> {
     terms: HashMap<String, ast::Term>,
     functions: HashMap<
         String,
-        Box<Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>>,
+        Box<
+            'ctx + Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>,
+        >,
     >,
 }
 
@@ -72,8 +74,7 @@ impl<'ctx> MessageContext<'ctx> {
 
     pub fn add_function<F>(&mut self, id: &str, func: F)
     where
-        F: 'static
-            + Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>,
+        F: 'ctx + Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>,
     {
         self.functions.insert(id.to_string(), Box::new(func));
     }
@@ -82,7 +83,9 @@ impl<'ctx> MessageContext<'ctx> {
         &self,
         id: &str,
     ) -> Option<
-        &Box<Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>>,
+        &Box<
+            'ctx + Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>,
+        >,
     > {
         self.functions.get(id)
     }

--- a/src/intl/mod.rs
+++ b/src/intl/mod.rs
@@ -165,7 +165,8 @@ static PLURAL_RULES: &[fn(f32) -> &'static str] = &[
         if is_between(n % 10.0, 2.0, 4.0) && !is_between(n % 100.0, 12.0, 14.0) {
             return "few";
         }
-        if n != 1.0 && is_between(n % 10.0, 0.0, 1.0) || is_between(n % 10.0, 5.0, 9.0)
+        if n != 1.0 && is_between(n % 10.0, 0.0, 1.0)
+            || is_between(n % 10.0, 5.0, 9.0)
             || is_between(n % 100.0, 12.0, 14.0)
         {
             return "many";
@@ -251,7 +252,8 @@ static PLURAL_RULES: &[fn(f32) -> &'static str] = &[
     /* 20 */
     |n| {
         if (is_between(n % 10.0, 3.0, 4.0) || n % 10.0 == 9.0)
-            && !(is_between(n % 100.0, 10.0, 19.0) || is_between(n % 100.0, 70.0, 79.0)
+            && !(is_between(n % 100.0, 10.0, 19.0)
+                || is_between(n % 100.0, 70.0, 79.0)
                 || is_between(n % 100.0, 90.0, 99.0))
         {
             return "few";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,10 @@
 //! assert_eq!(value, "Welcome, John.");
 //! ```
 
-pub mod syntax;
 pub mod context;
-pub mod resolve;
-pub mod types;
 pub mod intl;
+pub mod resolve;
+pub mod syntax;
+pub mod types;
 
 pub use context::MessageContext;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -181,34 +181,31 @@ impl ResolveValue for ast::Expression {
                 ref callee,
                 ref args,
             } => {
-                use resolve::ResolveValue;
-                use syntax;
 
                 let mut resolved_unnamed_args = Vec::new();
                 let mut resolved_named_args = HashMap::new();
 
                 for arg in args {
                     match arg {
-                        ast::Argument::Expression(expression) => {
+                        &ast::Argument::Expression(ref expression) => {
                             if let Some(resolved_expression) = expression.to_value(env) {
                                 resolved_unnamed_args.push(resolved_expression);
                             }
                         }
-                        ast::Argument::NamedArgument { name, val } => {
+                        &ast::Argument::NamedArgument { ref name, ref val } => {
                             let mut fluent_val: FluentValue;
 
                             match val {
-                                syntax::ast::ArgValue::Number(num) => {
+                                &ast::ArgValue::Number(ref num) => {
                                     fluent_val = num.to_value(env).unwrap();
                                 }
-                                syntax::ast::ArgValue::String(string) => {
+                                &ast::ArgValue::String(ref string) => {
                                     fluent_val = FluentValue::String(string.to_string());
                                 }
                             };
 
                             resolved_named_args.insert(name.name.clone(), fluent_val);
                         }
-                        _ => unimplemented!(),
                     }
                 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -9,9 +9,9 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use super::types::FluentValue;
-use super::syntax::ast;
 use super::context::MessageContext;
+use super::syntax::ast;
+use super::types::FluentValue;
 
 /// State for a single `ResolveValue::to_value` call.
 pub struct Env<'env> {
@@ -48,7 +48,8 @@ impl ResolveValue for ast::Attribute {
 
 impl ResolveValue for ast::Pattern {
     fn to_value(&self, env: &Env) -> Option<FluentValue> {
-        let string = self.elements
+        let string = self
+            .elements
             .iter()
             .map(|elem| {
                 elem.to_value(env)
@@ -87,13 +88,16 @@ impl ResolveValue for ast::Expression {
                 Some(FluentValue::from(value.clone()))
             }
             ast::Expression::NumberExpression { ref value } => value.to_value(env),
-            ast::Expression::MessageReference { ref id } if id.name.starts_with('-') => env.ctx
+            ast::Expression::MessageReference { ref id } if id.name.starts_with('-') => env
+                .ctx
                 .get_term(&id.name)
                 .and_then(|term| term.to_value(env)),
-            ast::Expression::MessageReference { ref id } => env.ctx
+            ast::Expression::MessageReference { ref id } => env
+                .ctx
                 .get_message(&id.name)
                 .and_then(|message| message.to_value(env)),
-            ast::Expression::ExternalArgument { ref id } => env.args
+            ast::Expression::ExternalArgument { ref id } => env
+                .args
                 .and_then(|args| args.get(&id.name.as_ref()))
                 .cloned(),
             ast::Expression::SelectExpression {

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -101,7 +101,7 @@ pub enum ArgValue {
     String(String),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Identifier {
     pub name: String,
 }

--- a/src/syntax/errors/display.rs
+++ b/src/syntax/errors/display.rs
@@ -1,10 +1,10 @@
 extern crate ansi_term;
 
-use std::cmp;
 use self::ansi_term::Colour::{Fixed, White};
-use super::list::ErrorKind;
-use super::list::ErrorInfo;
 use super::list::get_error_desc;
+use super::list::ErrorInfo;
+use super::list::ErrorKind;
+use std::cmp;
 
 pub enum Item {
     Error(ErrorKind),
@@ -33,14 +33,12 @@ pub fn annotate_slice(info: &ErrorInfo, file_name: Option<String>, item: &Item) 
 
     let (id, title, text) = desc.unwrap_or(("", "".to_owned(), ""));
 
-    let labels = [
-        Label {
-            start_pos: info.pos,
-            end_pos: info.pos + 1,
-            kind: LabelKind::Primary,
-            text: text,
-        },
-    ];
+    let labels = [Label {
+        start_pos: info.pos,
+        end_pos: info.pos + 1,
+        kind: LabelKind::Primary,
+        text: text,
+    }];
 
     let lines_num = cmp::max(info.slice.lines().count(), 1);
     let max_ln_width = get_ln_width(info.line + lines_num);
@@ -166,7 +164,7 @@ fn format_labels(
                 "{} {}\n",
                 Fixed(12)
                     .bold()
-                    .paint(format!("{} |", " ".repeat(max_ln_width)),),
+                    .paint(format!("{} |", " ".repeat(max_ln_width))),
                 format!("{}{} {}", pad, color.paint(mark), color.paint(label.text))
             );
             return Some(result);

--- a/src/syntax/errors/mod.rs
+++ b/src/syntax/errors/mod.rs
@@ -1,13 +1,13 @@
 pub mod display;
 mod list;
 
-pub use self::list::ParserError;
-pub use self::list::ErrorKind;
-pub use self::list::ErrorInfo;
 pub use self::list::get_error_desc;
+pub use self::list::ErrorInfo;
+pub use self::list::ErrorKind;
+pub use self::list::ParserError;
 
 macro_rules! error {
-    ($kind: expr) => {{
+    ($kind:expr) => {{
         Err(ParserError {
             info: None,
             kind: $kind,

--- a/src/syntax/errors/mod.rs
+++ b/src/syntax/errors/mod.rs
@@ -7,10 +7,10 @@ pub use self::list::ErrorInfo;
 pub use self::list::get_error_desc;
 
 macro_rules! error {
-    ($kind:expr) => {{
+    ($kind: expr) => {{
         Err(ParserError {
             info: None,
-            kind: $kind
+            kind: $kind,
         })
     }};
 }

--- a/src/syntax/ftlstream.rs
+++ b/src/syntax/ftlstream.rs
@@ -1,7 +1,7 @@
-use super::errors::ParserError;
 use super::errors::ErrorKind;
-use super::stream::ParserStream;
+use super::errors::ParserError;
 use super::parser::Result;
+use super::stream::ParserStream;
 
 pub trait FTLParserStream<I> {
     fn skip_inline_ws(&mut self);
@@ -320,7 +320,9 @@ where
             if self.current_is('\n') && !self.peek_char_is('\n') {
                 self.next();
 
-                if self.ch.is_none() || self.is_entry_id_start() || self.current_is('#')
+                if self.ch.is_none()
+                    || self.is_entry_id_start()
+                    || self.current_is('#')
                     || (self.current_is('/') && self.peek_char_is('/'))
                     || (self.current_is('[') && self.peek_char_is('['))
                 {

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -8,8 +8,8 @@
 #[macro_use]
 pub mod errors;
 pub mod ast;
+pub mod ftlstream;
 pub mod parser;
 pub mod stream;
-pub mod ftlstream;
 
 pub use self::parser::parse;

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -563,9 +563,7 @@ where
             let val = get_arg_val(ps)?;
             Ok(ast::Argument::NamedArgument { name: id, val })
         }
-        _ => {
-            error!(ErrorKind::ForbiddenKey)
-        }
+        _ => error!(ErrorKind::ForbiddenKey),
     }
 }
 

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1,10 +1,10 @@
-pub use super::errors::ParserError;
-pub use super::errors::ErrorKind;
-pub use super::errors::get_error_slice;
 pub use super::errors::get_error_info;
+pub use super::errors::get_error_slice;
+pub use super::errors::ErrorKind;
+pub use super::errors::ParserError;
 
-use super::stream::ParserStream;
 use super::ftlstream::FTLParserStream;
+use super::stream::ParserStream;
 
 use std::result;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,8 @@
 mod context;
+mod intl;
 mod resolve_attribute_expression;
 mod resolve_external_argument;
 mod resolve_message_reference;
 mod resolve_select_expression;
 mod resolve_value;
 mod syntax;
-mod intl;

--- a/tests/resolve_attribute_expression.rs
+++ b/tests/resolve_attribute_expression.rs
@@ -23,27 +23,33 @@ missing-missing = { missing.missing }
 ",
     );
 
-    let value = ctx.get_message("use-foo")
+    let value = ctx
+        .get_message("use-foo")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx.get_message("use-foo-attr")
+    let value = ctx
+        .get_message("use-foo-attr")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Foo Attr".to_string()));
 
-    let value = ctx.get_message("use-bar")
+    let value = ctx
+        .get_message("use-bar")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("___".to_string()));
 
-    let value = ctx.get_message("use-bar-attr")
+    let value = ctx
+        .get_message("use-bar-attr")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Bar Attr".to_string()));
 
-    let value = ctx.get_message("missing-attr")
+    let value = ctx
+        .get_message("missing-attr")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("___".to_string()));
 
-    let value = ctx.get_message("missing-missing")
+    let value = ctx
+        .get_message("missing-missing")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("___".to_string()));
 }

--- a/tests/resolve_external_argument.rs
+++ b/tests/resolve_external_argument.rs
@@ -14,7 +14,8 @@ fn external_argument_string() {
     let mut args = HashMap::new();
     args.insert("name", FluentValue::from("John"));
 
-    let value = ctx.get_message("hello-world")
+    let value = ctx
+        .get_message("hello-world")
         .and_then(|msg| ctx.format(msg, Some(&args)));
 
     assert_eq!(value, Some("Hello John".to_string()));
@@ -29,7 +30,8 @@ fn external_argument_number() {
     let mut args = HashMap::new();
     args.insert("emailsCount", FluentValue::from(5));
 
-    let value = ctx.get_message("unread-emails")
+    let value = ctx
+        .get_message("unread-emails")
         .and_then(|msg| ctx.format(msg, Some(&args)));
 
     assert_eq!(value, Some("You have 5 unread emails.".to_string()));
@@ -45,7 +47,8 @@ fn reference_message_with_external_argument() {
     let mut args = HashMap::new();
     args.insert("userName", FluentValue::from("Mary"));
 
-    let value = ctx.get_message("click-on")
+    let value = ctx
+        .get_message("click-on")
         .and_then(|msg| ctx.format(msg, Some(&args)));
 
     assert_eq!(value, Some("Click on the `Hello, Mary` label.".to_string()));

--- a/tests/resolve_select_expression.rs
+++ b/tests/resolve_select_expression.rs
@@ -202,39 +202,48 @@ baz-unknown =
     args.insert("int", FluentValue::from(3));
     args.insert("float", FluentValue::from(2.72));
 
-    let value = ctx.get_message("foo-hit")
+    let value = ctx
+        .get_message("foo-hit")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Qux".to_string()));
 
-    let value = ctx.get_message("foo-miss")
+    let value = ctx
+        .get_message("foo-miss")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx.get_message("foo-unknown")
+    let value = ctx
+        .get_message("foo-unknown")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx.get_message("bar-hit")
+    let value = ctx
+        .get_message("bar-hit")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Bar 3".to_string()));
 
-    let value = ctx.get_message("bar-miss")
+    let value = ctx
+        .get_message("bar-miss")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Bar 1".to_string()));
 
-    let value = ctx.get_message("bar-unknown")
+    let value = ctx
+        .get_message("bar-unknown")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Bar 1".to_string()));
 
-    let value = ctx.get_message("baz-hit")
+    let value = ctx
+        .get_message("baz-hit")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Baz E".to_string()));
 
-    let value = ctx.get_message("baz-miss")
+    let value = ctx
+        .get_message("baz-miss")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Baz 1".to_string()));
 
-    let value = ctx.get_message("baz-unknown")
+    let value = ctx
+        .get_message("baz-unknown")
         .and_then(|msg| ctx.format(msg, Some(&args)));
     assert_eq!(value, Some("Baz 1".to_string()));
 }
@@ -256,7 +265,8 @@ use-bar =
 ",
     );
 
-    let value = ctx.get_message("use-bar")
+    let value = ctx
+        .get_message("use-bar")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Bar".to_string()));
 }
@@ -278,7 +288,8 @@ use-foo =
 ",
     );
 
-    let value = ctx.get_message("use-foo")
+    let value = ctx
+        .get_message("use-foo")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Foo".to_string()));
 }

--- a/tests/resolve_value.rs
+++ b/tests/resolve_value.rs
@@ -28,7 +28,8 @@ foo = Foo
 ",
     );
 
-    if let Some(attributes) = ctx.get_message("foo")
+    if let Some(attributes) = ctx
+        .get_message("foo")
         .and_then(|message| message.attributes.as_ref())
     {
         let value = attributes

--- a/tests/resolve_variant_expression.rs
+++ b/tests/resolve_variant_expression.rs
@@ -31,31 +31,38 @@ missing-missing = { -missing[missing] }
     let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx.get_message("use-foo")
+    let value = ctx
+        .get_message("use-foo")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx.get_message("use-foo-missing")
+    let value = ctx
+        .get_message("use-foo-missing")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx.get_message("use-bar")
+    let value = ctx
+        .get_message("use-bar")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx.get_message("use-bar-nominative")
+    let value = ctx
+        .get_message("use-bar-nominative")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx.get_message("use-bar-genitive")
+    let value = ctx
+        .get_message("use-bar-genitive")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Bar's".to_string()));
 
-    let value = ctx.get_message("use-bar-missing")
+    let value = ctx
+        .get_message("use-bar-missing")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx.get_message("missing-missing")
+    let value = ctx
+        .get_message("missing-missing")
         .and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("___".to_string()));
 }

--- a/tests/syntax/errors.rs
+++ b/tests/syntax/errors.rs
@@ -34,7 +34,7 @@ fn empty_errors() {
                     line: 0,
                     col: 0,
                     pos: 0,
-                }),
+                },),
                 error1.info
             );
         }
@@ -60,7 +60,7 @@ fn bad_id_start_errors() {
                     line: 0,
                     col: 0,
                     pos: 0,
-                }),
+                },),
                 error1.info
             );
         }
@@ -86,7 +86,7 @@ fn just_id_errors() {
                     line: 0,
                     col: 3,
                     pos: 3,
-                }),
+                },),
                 error1.info
             );
         }
@@ -112,7 +112,7 @@ fn no_equal_sign_errors() {
                     line: 0,
                     col: 4,
                     pos: 4,
-                }),
+                },),
                 error1.info
             );
         }
@@ -143,7 +143,7 @@ fn wrong_char_in_id_errors() {
                     line: 0,
                     col: 2,
                     pos: 14,
-                }),
+                },),
                 error1.info
             );
         }
@@ -169,7 +169,7 @@ fn missing_trait_value_errors() {
                     line: 0,
                     col: 5,
                     pos: 17,
-                }),
+                },),
                 error1.info
             );
         }
@@ -195,7 +195,7 @@ fn message_missing_fields_errors() {
                     line: 0,
                     col: 3,
                     pos: 3,
-                }),
+                },),
                 error1.info
             );
         }
@@ -227,7 +227,7 @@ fn private_errors() {
                     line: 1,
                     col: 10,
                     pos: 48,
-                }),
+                },),
                 error1.info
             );
 
@@ -246,7 +246,7 @@ fn private_errors() {
                     line: 7,
                     col: 10,
                     pos: 10,
-                }),
+                },),
                 error2.info
             );
 
@@ -260,7 +260,7 @@ fn private_errors() {
                     line: 9,
                     col: 23,
                     pos: 23,
-                }),
+                },),
                 error3.info
             );
 
@@ -274,7 +274,7 @@ fn private_errors() {
                     line: 11,
                     col: 15,
                     pos: 15,
-                }),
+                },),
                 error4.info
             );
         }

--- a/tests/syntax/errors.rs
+++ b/tests/syntax/errors.rs
@@ -1,12 +1,12 @@
 extern crate fluent;
 
-use std::io::prelude::*;
 use std::fs::File;
 use std::io;
+use std::io::prelude::*;
 
-use self::fluent::syntax::parse;
-use self::fluent::syntax::errors::ErrorKind;
 use self::fluent::syntax::errors::ErrorInfo;
+use self::fluent::syntax::errors::ErrorKind;
+use self::fluent::syntax::parse;
 
 fn read_file(path: &str) -> Result<String, io::Error> {
     let mut f = try!(File::open(path));

--- a/tests/syntax/fixtures.rs
+++ b/tests/syntax/fixtures.rs
@@ -2,9 +2,9 @@ extern crate fluent;
 extern crate glob;
 
 use self::glob::glob;
-use std::io::prelude::*;
 use std::fs::File;
 use std::io;
+use std::io::prelude::*;
 
 use self::fluent::syntax::parse;
 

--- a/tests/syntax/junk.rs
+++ b/tests/syntax/junk.rs
@@ -1,8 +1,8 @@
 extern crate fluent;
 
-use std::io::prelude::*;
 use std::fs::File;
 use std::io;
+use std::io::prelude::*;
 
 use self::fluent::syntax::parse;
 

--- a/tests/syntax/mod.rs
+++ b/tests/syntax/mod.rs
@@ -1,4 +1,4 @@
-mod stream;
+mod errors;
 mod fixtures;
 mod junk;
-mod errors;
+mod stream;


### PR DESCRIPTION
Request for Review.

Some questions arose while implementing this feature.

- Should the custom functions be able to return `None` or always return a `FluentValue`?
- Should the custom functions be `FnMut` or be stateless?
- Can this same code be implemented using non-boxed closures? The `Box` is a bit of an eyesore but is needed due to a `Sized` trait requirement for storing the functions?

Otherwise, the code works as intended according to the [functions portion of the Project Fluent spec](http://projectfluent.org/fluent/guide/functions.html). Please let me know if I missed anything or how to improve this pull request before merging. 👍 