### PR TITLE
Resolve Cyclic Reference Issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ categories = ["localization", "internationalization"]
 getopts = "0.2.17"
 fluent-locale = "0.3.1"
 annotate-snippets = {version = "0.1", features = ["color"]}
+failure = "0.1.1"
+failure_derive = "0.1.1"
 
 [dev-dependencies]
 glob = "0.2.11"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Fail)]
+pub enum FluentError {
+    #[fail(
+        display = "attempted to override an existing {}: {}",
+        kind,
+        id
+    )]
+    Overriding { kind: &'static str, id: String },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,12 @@
 //! assert_eq!(value, "Welcome, John.");
 //! ```
 
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+
 pub mod context;
+pub mod errors;
 pub mod intl;
 pub mod resolve;
 pub mod syntax;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -65,10 +65,7 @@ pub trait ResolveValue {
 impl ResolveValue for ast::Message {
     fn to_value(&self, env: &Env) -> Result<FluentValue, FluentError> {
         env.track(&self.id.name, || {
-            self.value
-                .as_ref()
-                .ok_or(FluentError::None)?
-                .to_value(env)
+            self.value.as_ref().ok_or(FluentError::None)?.to_value(env)
         })
     }
 }

--- a/tests/resolve_message_reference.rs
+++ b/tests/resolve_message_reference.rs
@@ -60,17 +60,37 @@ fn message_reference_missing() {
 
 #[test]
 fn message_reference_cyclic() {
-    let mut ctx = MessageContext::new(&["x-testing"]);
+    {
+        let mut ctx = MessageContext::new(&["x-testing"]);
 
-    ctx.add_messages(
-        "
+        ctx.add_messages(
+            "
 foo = Foo { bar }
 bar = { foo } Bar
 ",
-    );
+        );
 
-    let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
-    assert_eq!(value, Some("Foo ___".to_string()));
+        let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+        assert_eq!(value, Some("Foo ___".to_string()));
+        let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+        assert_eq!(value, Some("___ Bar".to_string()));
+    }
+
+    {
+        let mut ctx = MessageContext::new(&["x-testing"]);
+
+        ctx.add_messages(
+            "
+foo = { bar }
+bar = { foo }
+",
+        );
+
+        let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+        assert_eq!(value, Some("___".to_string()));
+        let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+        assert_eq!(value, Some("___".to_string()));
+    }
 }
 
 #[test]

--- a/tests/resolve_message_reference.rs
+++ b/tests/resolve_message_reference.rs
@@ -59,7 +59,6 @@ fn message_reference_missing() {
 }
 
 #[test]
-#[ignore]
 fn message_reference_cyclic() {
     let mut ctx = MessageContext::new(&["x-testing"]);
 
@@ -72,4 +71,19 @@ bar = { foo } Bar
 
     let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
     assert_eq!(value, Some("Foo ___".to_string()));
+}
+
+#[test]
+fn message_reference_multiple() {
+    let mut ctx = MessageContext::new(&["x-testing"]);
+
+    ctx.add_messages(
+        "
+foo = Foo
+bar = { foo } Bar { foo }
+",
+    );
+
+    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    assert_eq!(value, Some("Foo Bar Foo".to_string()));
 }


### PR DESCRIPTION
- `MessageContext` now uses a single map for messages, terms, functions
- `ResolveValue::to_value` now returns a Result, required to handle cyclic resolves
- Cyclic resolves are no longer an issue, due to tracking previously-tracked identifiers
- An extra test was added for resolving a message multiple times within the same expression

Closes #20 
Closes #21 