### PR TITLE
Remove an extra MessageReference {id} in ResolveValue for Expression

### DIFF
--- a/fluent/src/resolve.rs
+++ b/fluent/src/resolve.rs
@@ -129,11 +129,6 @@ impl ResolveValue for ast::Expression {
         match self {
             ast::Expression::StringExpression { value } => Ok(FluentValue::from(value.clone())),
             ast::Expression::NumberExpression { value } => value.to_value(env),
-            ast::Expression::MessageReference { id } if id.name.starts_with('-') => env
-                .ctx
-                .get_term(&id.name)
-                .ok_or(FluentError::None)?
-                .to_value(env),
             ast::Expression::MessageReference { ref id } if id.name.starts_with('-') => env
                 .ctx
                 .get_term(&id.name)

--- a/fluent/src/resolve.rs
+++ b/fluent/src/resolve.rs
@@ -132,13 +132,13 @@ impl ResolveValue for ast::Expression {
             ast::Expression::MessageReference { ref id } if id.name.starts_with('-') => env
                 .ctx
                 .get_term(&id.name)
-                .ok_or(FluentError::None)
-                .and_then(|term| term.to_value(env)),
+                .ok_or(FluentError::None)?
+                .to_value(env),
             ast::Expression::MessageReference { ref id } => env
                 .ctx
                 .get_message(&id.name)
-                .ok_or(FluentError::None)
-                .and_then(|message| message.to_value(env)),
+                .ok_or(FluentError::None)?
+                .to_value(env),
             ast::Expression::ExternalArgument { ref id } => env
                 .args
                 .and_then(|args| args.get(&id.name.as_ref()))


### PR DESCRIPTION
The proper way to handle term references was introduced in #50.