### PR TITLE
MessageContext.format now takes an id

### DIFF
--- a/fluent/examples/external_arguments.rs
+++ b/fluent/examples/external_arguments.rs
@@ -1,12 +1,11 @@
 extern crate fluent;
 
-use fluent::context::MessageContext;
+use fluent::MessageContext;
 use fluent::types::FluentValue;
 use std::collections::HashMap;
 
 fn main() {
     let mut ctx = MessageContext::new(&["en"]);
-
     ctx.add_messages(
         "
 hello-world = Hello { $name }
@@ -22,18 +21,12 @@ unread-emails =
     let mut args = HashMap::new();
     args.insert("name", FluentValue::from("John"));
 
-    match ctx
-        .get_message("hello-world")
-        .and_then(|msg| ctx.format(msg, Some(&args)))
-    {
+    match ctx.format("hello-world", Some(&args)) {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }
 
-    match ctx
-        .get_message("ref")
-        .and_then(|msg| ctx.format(msg, Some(&args)))
-    {
+    match ctx.format("ref", Some(&args)) {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }
@@ -41,10 +34,7 @@ unread-emails =
     let mut args = HashMap::new();
     args.insert("emailCount", FluentValue::as_number("1.0").unwrap());
 
-    match ctx
-        .get_message("unread-emails")
-        .and_then(|msg| ctx.format(msg, Some(&args)))
-    {
+    match ctx.format("unread-emails", Some(&args)) {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }

--- a/fluent/examples/external_arguments.rs
+++ b/fluent/examples/external_arguments.rs
@@ -1,7 +1,7 @@
 extern crate fluent;
 
-use fluent::MessageContext;
 use fluent::types::FluentValue;
+use fluent::MessageContext;
 use std::collections::HashMap;
 
 fn main() {

--- a/fluent/examples/functions.rs
+++ b/fluent/examples/functions.rs
@@ -38,21 +38,15 @@ fn main() {
     ctx.add_messages("meaning-of-life = { MEANING_OF_LIFE(42) }");
     ctx.add_messages("all-your-base = { BASE_OWNERSHIP(hello, ownership: \"us\") }");
 
-    let value = ctx
-        .get_message("hello-world")
-        .and_then(|message| ctx.format(message, None));
+    let value = ctx.format("hello-world", None);
     assert_eq!(value, Some("Hey there! I'm a function!".to_string()));
 
-    let value = ctx
-        .get_message("meaning-of-life")
-        .and_then(|message| ctx.format(message, None));
+    let value = ctx.format("meaning-of-life", None);
     assert_eq!(
         value,
         Some("The answer to life, the universe, and everything".to_string())
     );
 
-    let value = ctx
-        .get_message("all-your-base")
-        .and_then(|message| ctx.format(message, None));
+    let value = ctx.format("all-your-base", None);
     assert_eq!(value, Some("All your base belong to us".to_string()));
 }

--- a/fluent/examples/hello.rs
+++ b/fluent/examples/hello.rs
@@ -6,9 +6,6 @@ fn main() {
     let mut ctx = MessageContext::new(&["en-US"]);
     ctx.add_messages("hello-world = Hello, world!");
 
-    let value = ctx
-        .get_message("hello-world")
-        .and_then(|message| ctx.format(message, None));
-
+    let value = ctx.format("hello-world", None);
     assert_eq!(value, Some("Hello, world!".to_string()));
 }

--- a/fluent/examples/message_reference.rs
+++ b/fluent/examples/message_reference.rs
@@ -4,7 +4,6 @@ use fluent::context::MessageContext;
 
 fn main() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo = Foo
@@ -13,18 +12,12 @@ bazbar = { baz } Bar
 ",
     );
 
-    match ctx
-        .get_message("foobar")
-        .and_then(|msg| ctx.format(msg, None))
-    {
+    match ctx.format("foobar", None) {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }
 
-    match ctx
-        .get_message("bazbar")
-        .and_then(|msg| ctx.format(msg, None))
-    {
+    match ctx.format("bazbar", None) {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }

--- a/fluent/examples/selector.rs
+++ b/fluent/examples/selector.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 
 fn main() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 hello-world = Hello {
@@ -21,10 +20,7 @@ hello-world2 = Hello { $name ->
 ",
     );
 
-    match ctx
-        .get_message("hello-world")
-        .and_then(|msg| ctx.format(msg, None))
-    {
+    match ctx.format("hello-world", None) {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }
@@ -32,10 +28,7 @@ hello-world2 = Hello { $name ->
     let mut args = HashMap::new();
     args.insert("name", FluentValue::from("moon"));
 
-    match ctx
-        .get_message("hello-world2")
-        .and_then(|msg| ctx.format(msg, Some(&args)))
-    {
+    match ctx.format("hello-world2", Some(&args)) {
         Some(value) => println!("{}", value),
         None => println!("None"),
     }

--- a/fluent/examples/simple.rs
+++ b/fluent/examples/simple.rs
@@ -138,8 +138,8 @@ fn main() {
                     // 6.3. Format the message.
                     println!(
                         "{}",
-                        ctx.get_message("response-msg")
-                            .and_then(|msg| ctx.format(msg, Some(&args)))
+                        ctx
+                            .format("response-msg", Some(&args))
                             .unwrap()
                     );
                 }
@@ -149,8 +149,8 @@ fn main() {
                     args.insert("reason", FluentValue::from(err.to_string()));
                     println!(
                         "{}",
-                        ctx.get_message("input-parse-error")
-                            .and_then(|msg| ctx.format(msg, Some(&args)))
+                        ctx
+                            .format("input-parse-error-msg", Some(&args))
                             .unwrap()
                     );
                 }
@@ -159,8 +159,8 @@ fn main() {
         None => {
             println!(
                 "{}",
-                ctx.get_message("missing-arg-error")
-                    .and_then(|msg| ctx.format(msg, None))
+                ctx
+                    .format("missing-arg-error", None)
                     .unwrap()
             );
         }

--- a/fluent/src/context.rs
+++ b/fluent/src/context.rs
@@ -90,20 +90,10 @@ impl<'ctx> MessageContext<'ctx> {
         })
     }
 
-    pub fn get_message(&self, id: &str) -> Option<&ast::Message> {
+    fn get_message(&self, id: &str) -> Option<&ast::Message> {
         self.entries.get(id).and_then(|id| {
             if let Entry::Message(ref msg) = id {
                 Some(msg)
-            } else {
-                None
-            }
-        })
-    }
-
-    pub fn get_term(&self, id: &str) -> Option<&ast::Term> {
-        self.entries.get(id).and_then(|id| {
-            if let Entry::Term(ref term) = id {
-                Some(term)
             } else {
                 None
             }
@@ -124,23 +114,6 @@ impl<'ctx> MessageContext<'ctx> {
                 id: id.to_owned(),
             }),
         }
-    }
-
-    pub fn get_function(
-        &self,
-        id: &str,
-    ) -> Option<
-        &Box<
-            'ctx + Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>,
-        >,
-    > {
-        self.entries.get(id).and_then(|id| {
-            if let Entry::Function(ref func) = id {
-                Some(func)
-            } else {
-                None
-            }
-        })
     }
 
     pub fn add_messages(&mut self, source: &str) -> Result<(), FluentError> {

--- a/fluent/src/entry.rs
+++ b/fluent/src/entry.rs
@@ -1,0 +1,43 @@
+//! `Entry` is used to store Messages, Terms and Functions in `MessageContext` instances.
+use std::collections::hash_map::HashMap;
+
+use super::types::FluentValue;
+use fluent_syntax::ast;
+
+type FluentFunction<'ctx> =
+    Box<'ctx + Fn(&[Option<FluentValue>], &HashMap<String, FluentValue>) -> Option<FluentValue>>;
+
+pub enum Entry<'ctx> {
+    Message(ast::Message),
+    Term(ast::Term),
+    Function(FluentFunction<'ctx>),
+}
+
+pub trait GetEntry<'ctx> {
+    fn get_term(&self, id: &str) -> Option<&ast::Term>;
+    fn get_message(&self, id: &str) -> Option<&ast::Message>;
+    fn get_function(&self, id: &str) -> Option<&FluentFunction<'ctx>>;
+}
+
+impl<'ctx> GetEntry<'ctx> for HashMap<String, Entry<'ctx>> {
+    fn get_term(&self, id: &str) -> Option<&ast::Term> {
+        self.get(id).and_then(|entry| match entry {
+            Entry::Term(term) => Some(term),
+            _ => None,
+        })
+    }
+
+    fn get_message(&self, id: &str) -> Option<&ast::Message> {
+        self.get(id).and_then(|entry| match entry {
+            Entry::Message(message) => Some(message),
+            _ => None,
+        })
+    }
+
+    fn get_function(&self, id: &str) -> Option<&FluentFunction<'ctx>> {
+        self.get(id).and_then(|entry| match entry {
+            Entry::Function(function) => Some(function),
+            _ => None,
+        })
+    }
+}

--- a/fluent/src/errors.rs
+++ b/fluent/src/errors.rs
@@ -1,9 +1,5 @@
 #[derive(Debug, Fail)]
 pub enum FluentError {
-    #[fail(
-        display = "attempted to override an existing {}: {}",
-        kind,
-        id
-    )]
+    #[fail(display = "attempted to override an existing {}: {}", kind, id)]
     Overriding { kind: &'static str, id: String },
 }

--- a/fluent/src/lib.rs
+++ b/fluent/src/lib.rs
@@ -41,6 +41,7 @@ extern crate fluent_syntax;
 extern crate intl_pluralrules;
 
 pub mod context;
+pub mod entry;
 pub mod errors;
 pub mod resolve;
 pub mod types;

--- a/fluent/src/lib.rs
+++ b/fluent/src/lib.rs
@@ -16,7 +16,6 @@
 //! use std::collections::HashMap;
 //!
 //! let mut ctx = MessageContext::new(&["en-US"]);
-//!
 //! ctx.add_messages(
 //!     "
 //! hello-world = Hello, world!
@@ -24,17 +23,13 @@
 //! "
 //!     );
 //!
-//! let msg = ctx.get_message("hello-world").unwrap();
-//! let value = ctx.format(msg, None).unwrap();
-//!
+//! let value = ctx.format("hello-world", None).unwrap();
 //! assert_eq!(value, "Hello, world!");
 //!
 //! let mut args = HashMap::new();
 //! args.insert("name", FluentValue::from("John"));
 //!
-//! let msg = ctx.get_message("intro").unwrap();
-//! let value = ctx.format(msg, Some(&args)).unwrap();
-//!
+//! let value = ctx.format("intro", Some(&args)).unwrap();
 //! assert_eq!(value, "Welcome, John.");
 //! ```
 

--- a/fluent/tests/format.rs
+++ b/fluent/tests/format.rs
@@ -1,0 +1,39 @@
+extern crate fluent;
+
+use self::fluent::context::MessageContext;
+
+#[test]
+fn format() {
+    let mut ctx = MessageContext::new(&["x-testing"]);
+    ctx.add_messages(
+        "
+foo = Foo
+    .attr = Attribute
+-term = Term
+",
+    );
+
+    let value = ctx.format("foo", None);
+    assert_eq!(value, Some("Foo".to_string()));
+
+    let value = ctx.format("foo.attr", None);
+    assert_eq!(value, Some("Attribute".to_string()));
+
+    let value = ctx.format("foo.missing", None);
+    assert_eq!(value, None);
+
+    let value = ctx.format("foo.attr.nested", None);
+    assert_eq!(value, None);
+
+    let value = ctx.format("missing", None);
+    assert_eq!(value, None);
+
+    let value = ctx.format("missing.attr", None);
+    assert_eq!(value, None);
+
+    let value = ctx.format("-term", None);
+    assert_eq!(value, None);
+
+    let value = ctx.format("-term.attr", None);
+    assert_eq!(value, None);
+}

--- a/fluent/tests/resolve_attribute_expression.rs
+++ b/fluent/tests/resolve_attribute_expression.rs
@@ -23,33 +23,21 @@ missing-missing = { missing.missing }
 ",
     );
 
-    let value = ctx
-        .get_message("use-foo")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-foo", None);
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx
-        .get_message("use-foo-attr")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-foo-attr", None);
     assert_eq!(value, Some("Foo Attr".to_string()));
 
-    let value = ctx
-        .get_message("use-bar")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-bar", None);
     assert_eq!(value, Some("___".to_string()));
 
-    let value = ctx
-        .get_message("use-bar-attr")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-bar-attr", None);
     assert_eq!(value, Some("Bar Attr".to_string()));
 
-    let value = ctx
-        .get_message("missing-attr")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("missing-attr", None);
     assert_eq!(value, Some("___".to_string()));
 
-    let value = ctx
-        .get_message("missing-missing")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("missing-missing", None);
     assert_eq!(value, Some("___".to_string()));
 }

--- a/fluent/tests/resolve_external_argument.rs
+++ b/fluent/tests/resolve_external_argument.rs
@@ -14,10 +14,7 @@ fn external_argument_string() {
     let mut args = HashMap::new();
     args.insert("name", FluentValue::from("John"));
 
-    let value = ctx
-        .get_message("hello-world")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
-
+    let value = ctx.format("hello-world", Some(&args));
     assert_eq!(value, Some("Hello John".to_string()));
 }
 
@@ -32,16 +29,10 @@ fn external_argument_number() {
     args.insert("emailsCount", FluentValue::from(5));
     args.insert("emailsCountDec", FluentValue::as_number("5.0").unwrap());
 
-    let value = ctx
-        .get_message("unread-emails")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
-
+    let value = ctx.format("unread-emails", Some(&args));
     assert_eq!(value, Some("You have 5 unread emails.".to_string()));
 
-    let value = ctx
-        .get_message("unread-emails-dec")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
-
+    let value = ctx.format("unread-emails-dec", Some(&args));
     assert_eq!(value, Some("You have 5.0 unread emails.".to_string()));
 }
 
@@ -55,9 +46,6 @@ fn reference_message_with_external_argument() {
     let mut args = HashMap::new();
     args.insert("userName", FluentValue::from("Mary"));
 
-    let value = ctx
-        .get_message("click-on")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
-
+    let value = ctx.format("click-on", Some(&args));
     assert_eq!(value, Some("Click on the `Hello, Mary` label.".to_string()));
 }

--- a/fluent/tests/resolve_message_reference.rs
+++ b/fluent/tests/resolve_message_reference.rs
@@ -5,7 +5,6 @@ use self::fluent::context::MessageContext;
 #[test]
 fn message_reference() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo = Foo
@@ -13,14 +12,13 @@ bar = { foo } Bar
 ",
     );
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("Foo Bar".to_string()));
 }
 
 #[test]
 fn term_reference() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 -foo = Foo
@@ -28,14 +26,13 @@ bar = { -foo } Bar
 ",
     );
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("Foo Bar".to_string()));
 }
 
 #[test]
 fn message_reference_nested() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo = Foo
@@ -44,17 +41,16 @@ baz = { bar } Baz
 ",
     );
 
-    let value = ctx.get_message("baz").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("baz", None);
     assert_eq!(value, Some("Foo Bar Baz".to_string()));
 }
 
 #[test]
 fn message_reference_missing() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages("bar = { foo } Bar");
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("___ Bar".to_string()));
 }
 
@@ -62,7 +58,6 @@ fn message_reference_missing() {
 fn message_reference_cyclic() {
     {
         let mut ctx = MessageContext::new(&["x-testing"]);
-
         ctx.add_messages(
             "
 foo = Foo { bar }
@@ -70,15 +65,14 @@ bar = { foo } Bar
 ",
         );
 
-        let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+        let value = ctx.format("foo", None);
         assert_eq!(value, Some("Foo ___".to_string()));
-        let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+        let value = ctx.format("bar", None);
         assert_eq!(value, Some("___ Bar".to_string()));
     }
 
     {
         let mut ctx = MessageContext::new(&["x-testing"]);
-
         ctx.add_messages(
             "
 foo = { bar }
@@ -86,9 +80,9 @@ bar = { foo }
 ",
         );
 
-        let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+        let value = ctx.format("foo", None);
         assert_eq!(value, Some("___".to_string()));
-        let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+        let value = ctx.format("bar", None);
         assert_eq!(value, Some("___".to_string()));
     }
 }
@@ -96,7 +90,6 @@ bar = { foo }
 #[test]
 fn message_reference_multiple() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo = Foo
@@ -104,6 +97,6 @@ bar = { foo } Bar { foo }
 ",
     );
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("Foo Bar Foo".to_string()));
 }

--- a/fluent/tests/resolve_plural_rule.rs
+++ b/fluent/tests/resolve_plural_rule.rs
@@ -8,7 +8,6 @@ use self::fluent::types::FluentValue;
 #[test]
 fn external_argument_number() {
     let mut ctx = MessageContext::new(&["en"]);
-
     ctx.add_messages(
         "
 unread-emails =
@@ -30,23 +29,16 @@ unread-emails-dec =
     args.insert("emailsCount", FluentValue::from(1));
     args.insert("emailsCountDec", FluentValue::as_number("1.0").unwrap());
 
-    let value = ctx
-        .get_message("unread-emails")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
-
+    let value = ctx.format("unread-emails", Some(&args));
     assert_eq!(value, Some("You have 1 unread email.".to_string()));
 
-    let value = ctx
-        .get_message("unread-emails-dec")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
-
+    let value = ctx.format("unread-emails-dec", Some(&args));
     assert_eq!(value, Some("You have 1.0 unread emails.".to_string()));
 }
 
 #[test]
 fn exact_match() {
     let mut ctx = MessageContext::new(&["en"]);
-
     ctx.add_messages(
         "
 unread-emails =
@@ -70,15 +62,9 @@ unread-emails-dec =
     args.insert("emailsCount", FluentValue::from(1));
     args.insert("emailsCountDec", FluentValue::as_number("1.0").unwrap());
 
-    let value = ctx
-        .get_message("unread-emails")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
-
+    let value = ctx.format("unread-emails", Some(&args));
     assert_eq!(value, Some("You have one unread email.".to_string()));
 
-    let value = ctx
-        .get_message("unread-emails-dec")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
-
+    let value = ctx.format("unread-emails-dec", Some(&args));
     assert_eq!(value, Some("You have one unread email.".to_string()));
 }

--- a/fluent/tests/resolve_select_expression.rs
+++ b/fluent/tests/resolve_select_expression.rs
@@ -25,17 +25,16 @@ bar =
 ",
     );
 
-    let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("foo", None);
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("Bar".to_string()));
 }
 
 #[test]
 fn select_expression_string_selector() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo =
@@ -52,17 +51,16 @@ bar =
 ",
     );
 
-    let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("foo", None);
     assert_eq!(value, Some("Foo's".to_string()));
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("Bar".to_string()));
 }
 
 #[test]
 fn select_expression_number_selector() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo =
@@ -86,20 +84,19 @@ baz =
 ",
     );
 
-    let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("foo", None);
     assert_eq!(value, Some("Foo 3".to_string()));
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("Bar 1".to_string()));
 
-    let value = ctx.get_message("baz").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("baz", None);
     assert_eq!(value, Some("Baz Pi".to_string()));
 }
 
 #[test]
 fn select_expression_plurals() {
     let mut ctx = MessageContext::new(&["en"]);
-
     ctx.add_messages(
         "
 foo =
@@ -125,20 +122,19 @@ baz =
 ",
     );
 
-    let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("foo", None);
     assert_eq!(value, Some("Foo 3".to_string()));
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("Bar One".to_string()));
 
-    let value = ctx.get_message("baz").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("baz", None);
     assert_eq!(value, Some("Bar Other".to_string()));
 }
 
 #[test]
 fn select_expression_external_argument_selector() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo-hit =
@@ -202,56 +198,37 @@ baz-unknown =
     args.insert("int", FluentValue::from(3));
     args.insert("float", FluentValue::from(2.72));
 
-    let value = ctx
-        .get_message("foo-hit")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("foo-hit", Some(&args));
     assert_eq!(value, Some("Qux".to_string()));
 
-    let value = ctx
-        .get_message("foo-miss")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("foo-miss", Some(&args));
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx
-        .get_message("foo-unknown")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("foo-unknown", Some(&args));
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx
-        .get_message("bar-hit")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("bar-hit", Some(&args));
     assert_eq!(value, Some("Bar 3".to_string()));
 
-    let value = ctx
-        .get_message("bar-miss")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("bar-miss", Some(&args));
     assert_eq!(value, Some("Bar 1".to_string()));
 
-    let value = ctx
-        .get_message("bar-unknown")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("bar-unknown", Some(&args));
     assert_eq!(value, Some("Bar 1".to_string()));
 
-    let value = ctx
-        .get_message("baz-hit")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("baz-hit", Some(&args));
     assert_eq!(value, Some("Baz E".to_string()));
 
-    let value = ctx
-        .get_message("baz-miss")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("baz-miss", Some(&args));
     assert_eq!(value, Some("Baz 1".to_string()));
 
-    let value = ctx
-        .get_message("baz-unknown")
-        .and_then(|msg| ctx.format(msg, Some(&args)));
+    let value = ctx.format("baz-unknown", Some(&args));
     assert_eq!(value, Some("Baz 1".to_string()));
 }
 
 #[test]
 fn select_expression_message_selector() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 -bar = Bar
@@ -265,16 +242,13 @@ use-bar =
 ",
     );
 
-    let value = ctx
-        .get_message("use-bar")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-bar", None);
     assert_eq!(value, Some("Bar".to_string()));
 }
 
 #[test]
 fn select_expression_attribute_selector() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 -foo = Foo
@@ -288,8 +262,6 @@ use-foo =
 ",
     );
 
-    let value = ctx
-        .get_message("use-foo")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-foo", None);
     assert_eq!(value, Some("Foo".to_string()));
 }

--- a/fluent/tests/resolve_value.rs
+++ b/fluent/tests/resolve_value.rs
@@ -5,22 +5,20 @@ use self::fluent::context::MessageContext;
 #[test]
 fn format_message() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo = Foo
 ",
     );
 
-    let value = ctx.get_message("foo").and_then(|msg| ctx.format(msg, None));
-
+    let value = ctx.format("foo", None);
     assert_eq!(value, Some("Foo".to_string()));
 }
 
 #[test]
+#[ignore]
 fn format_attribute() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 foo = Foo
@@ -28,14 +26,6 @@ foo = Foo
 ",
     );
 
-    if let Some(attributes) = ctx
-        .get_message("foo")
-        .and_then(|message| message.attributes.as_ref())
-    {
-        let value = attributes
-            .first()
-            .and_then(|attribute| ctx.format(attribute, None));
-
-        assert_eq!(value, Some("Foo Attr".to_string()));
-    }
+    let value = ctx.format("foo.attr", None);
+    assert_eq!(value, Some("Foo Attr".to_string()));
 }

--- a/fluent/tests/resolve_value.rs
+++ b/fluent/tests/resolve_value.rs
@@ -16,7 +16,6 @@ foo = Foo
 }
 
 #[test]
-#[ignore]
 fn format_attribute() {
     let mut ctx = MessageContext::new(&["x-testing"]);
     ctx.add_messages(

--- a/fluent/tests/resolve_variant_expression.rs
+++ b/fluent/tests/resolve_variant_expression.rs
@@ -5,7 +5,6 @@ use self::fluent::context::MessageContext;
 #[test]
 fn variant_expression() {
     let mut ctx = MessageContext::new(&["x-testing"]);
-
     ctx.add_messages(
         "
 -foo = Foo
@@ -28,41 +27,27 @@ missing-missing = { -missing[missing] }
 ",
     );
 
-    let value = ctx.get_message("bar").and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("bar", None);
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx
-        .get_message("use-foo")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-foo", None);
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx
-        .get_message("use-foo-missing")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-foo-missing", None);
     assert_eq!(value, Some("Foo".to_string()));
 
-    let value = ctx
-        .get_message("use-bar")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-bar", None);
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx
-        .get_message("use-bar-nominative")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-bar-nominative", None);
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx
-        .get_message("use-bar-genitive")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-bar-genitive", None);
     assert_eq!(value, Some("Bar's".to_string()));
 
-    let value = ctx
-        .get_message("use-bar-missing")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("use-bar-missing", None);
     assert_eq!(value, Some("Bar".to_string()));
 
-    let value = ctx
-        .get_message("missing-missing")
-        .and_then(|msg| ctx.format(msg, None));
+    let value = ctx.format("missing-missing", None);
     assert_eq!(value, Some("___".to_string()));
 }


### PR DESCRIPTION
- Make `get_message` private.
- Remove `get_term` and `get_function`.
- `format` must now be called with the string id of the desired message:

        ctx.format("foo", None);

    It also accepts dot-separated paths identifying attributes:

        ctx.format("foo.attrname", None);

Fix #60.