### PR TITLE
Specific lifetime on initialiser

### DIFF
--- a/fluent/src/bundle.rs
+++ b/fluent/src/bundle.rs
@@ -56,7 +56,8 @@ pub struct FluentBundle<'bundle> {
 }
 
 impl<'bundle> FluentBundle<'bundle> {
-    pub fn new<S: ToString>(locales: &[S]) -> FluentBundle {
+    // pub fn new<S: ToString>(locales: &[S]) -> FluentBundle {
+    pub fn new<'a, S: ToString>(locales: &'a [S]) -> FluentBundle<'bundle> {
         let locales = locales
             .into_iter()
             .map(|s| s.to_string())

--- a/fluent/src/bundle.rs
+++ b/fluent/src/bundle.rs
@@ -56,7 +56,6 @@ pub struct FluentBundle<'bundle> {
 }
 
 impl<'bundle> FluentBundle<'bundle> {
-    // pub fn new<S: ToString>(locales: &[S]) -> FluentBundle {
     pub fn new<'a, S: ToString>(locales: &'a [S]) -> FluentBundle<'bundle> {
         let locales = locales
             .into_iter()

--- a/fluent/tests/bundle.rs
+++ b/fluent/tests/bundle.rs
@@ -39,3 +39,13 @@ fn bundle_new_from_strings() {
     let _ = FluentBundle::new(&vec_from_iter);
     let _ = FluentBundle::new(&vec_from_iter[..]);
 }
+
+fn create_bundle<'a, 'b>(locales: &'b Vec<&'b str>) -> FluentBundle<'a> {
+    FluentBundle::new(locales)
+}
+
+#[test]
+fn bundle_locale_diff_scope() {
+    let locales = vec!("x-testing");
+    create_bundle(&locales);
+}


### PR DESCRIPTION
When not explicitly defined, Rust will assign the same lifetime to all
input parameters and return values.

The FluentBundle::new constructor does not define an explicit lifetime
for the 'locale' input parameter, so it is assigned the same lifetime as
the bundle itself. This causes the borrow checker to reject code that
initialises bundles populated from dynamically loaded resources and
stored in separate containers.

This adds an explicit lifetime to the locales parameter to decouple it
from the return value and a test case that fails to compile without the
change.