### PR TITLE
Fix imports in hero example

### DIFF
--- a/fluent/README.md
+++ b/fluent/README.md
@@ -22,9 +22,7 @@ Usage
 -----
 
 ```rust
-extern crate fluent;
-
-use fluent::FluentBundle;
+use fluent::bundle::FluentBundle;
 
 fn main() {
     let mut bundle = FluentBundle::new(&["en-US"]);


### PR DESCRIPTION
* Use the proper mod path for FluentBundle
* Drop the `extern crate...` ceremony for 2018 edition

The example relied on a pub use that disappeared here: https://github.com/projectfluent/fluent-rs/commit/0f2e0922a948babe73a93c10bd9620864b382e04