### PR TITLE
Fix README.md

### DIFF
--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -25,7 +25,7 @@ Usage
 use fluent_bundle::{FluentBundle, FluentResource};
 
 fn main() {
-    let ftl_string = "hello-world = Hello, world!");
+    let ftl_string = "hello-world = Hello, world!".to_owned();
     let res = FluentResource::try_new(ftl_string)
         .expect("Could not parse an FTL string.");
 

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -22,10 +22,10 @@ Usage
 -----
 
 ```rust
-use fluent_bundle::{FluentBundle, FluentResource};
+use fluent::{FluentBundle, FluentResource};
 
 fn main() {
-    let ftl_string = "hello-world = Hello, world!");
+    let ftl_string = "hello-world = Hello, world!".to_owned();
     let res = FluentResource::try_new(ftl_string)
         .expect("Could not parse an FTL string.");
 


### PR DESCRIPTION
Added casts from `&'static str` into `String` to let the samples work. Also, on `fluent/README.md`, used the re-exports instead of using `fluent_bundle` directly.