### PR TITLE
Fix `bare_trait_objects` warnings

### DIFF
--- a/fluent-bundle/src/entry.rs
+++ b/fluent-bundle/src/entry.rs
@@ -4,7 +4,7 @@ use std::collections::hash_map::HashMap;
 use super::types::*;
 use fluent_syntax::ast;
 
-type FluentFunction<'bundle> = Box<
+type FluentFunction<'bundle> = Box<dyn
     'bundle
         + for<'a> Fn(&[FluentValue<'a>], &HashMap<&str, FluentValue<'a>>) -> FluentValue<'a>
         + Send

--- a/fluent-fallback/src/lib.rs
+++ b/fluent-fallback/src/lib.rs
@@ -6,7 +6,7 @@ use fluent_bundle::FluentValue;
 use reiterate::Reiterate;
 
 struct FluentBundleIterator<'loc> {
-    iter: Box<Iterator<Item = FluentBundle<'loc>> + 'loc>,
+    iter: Box<dyn Iterator<Item = FluentBundle<'loc>> + 'loc>,
 }
 
 impl<'loc> Iterator for FluentBundleIterator<'loc> {
@@ -19,7 +19,7 @@ impl<'loc> Iterator for FluentBundleIterator<'loc> {
 pub struct Localization<'loc> {
     pub resource_ids: Vec<String>,
     bundles: Reiterate<FluentBundleIterator<'loc>>,
-    generate_bundles: Box<FnMut(&[String]) -> FluentBundleIterator<'loc> + 'loc>,
+    generate_bundles: Box<dyn FnMut(&[String]) -> FluentBundleIterator<'loc> + 'loc>,
 }
 
 impl<'loc> Localization<'loc> {

--- a/fluent-syntax/tests/ast/mod.rs
+++ b/fluent-syntax/tests/ast/mod.rs
@@ -5,13 +5,13 @@ use serde::{Serialize, Serializer};
 use serde_derive::Serialize;
 use std::error::Error;
 
-pub fn serialize<'s>(res: &'s ast::Resource) -> Result<String, Box<Error>> {
+pub fn serialize<'s>(res: &'s ast::Resource) -> Result<String, Box<dyn Error>> {
     #[derive(Serialize)]
     struct Helper<'ast>(#[serde(with = "ResourceDef")] &'ast ast::Resource<'ast>);
     Ok(serde_json::to_string(&Helper(res)).unwrap())
 }
 
-pub fn _serialize_to_pretty_json<'s>(res: &'s ast::Resource) -> Result<String, Box<Error>> {
+pub fn _serialize_to_pretty_json<'s>(res: &'s ast::Resource) -> Result<String, Box<dyn Error>> {
     #[derive(Serialize)]
     struct Helper<'ast>(#[serde(with = "ResourceDef")] &'ast ast::Resource<'ast>);
 


### PR DESCRIPTION
This commit fixes warnings such as this one:

```
warning: trait objects without an explicit `dyn` are deprecated
 --> fluent-fallback\src\lib.rs:9:15
  |
9 |     iter: Box<Iterator<Item = FluentBundle<'loc>> + 'loc>,
  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Iterator<Item = FluentBundle<'loc>> + 'loc`
  |
  = note: #[warn(bare_trait_objects)] on by default
```

using the `dyn` keyword that's part of Rust 2018.