### PR TITLE
Protect against million laughs bomb

### DIFF
--- a/fluent-bundle/tests/fixtures/bomb.yaml
+++ b/fluent-bundle/tests/fixtures/bomb.yaml
@@ -1,0 +1,30 @@
+suites:
+  -
+    name: Reference bombs
+    suites:
+      -
+        name: Billion Laughs
+        resources:
+          -
+            source: |-
+              lol0 = LOL
+              lol1 = {lol0} {lol0} {lol0} {lol0} {lol0} {lol0} {lol0} {lol0} {lol0} {lol0}
+              lol2 = {lol1} {lol1} {lol1} {lol1} {lol1} {lol1} {lol1} {lol1} {lol1} {lol1}
+              lol3 = {lol2} {lol2} {lol2} {lol2} {lol2} {lol2} {lol2} {lol2} {lol2} {lol2}
+              lol4 = {lol3} {lol3} {lol3} {lol3} {lol3} {lol3} {lol3} {lol3} {lol3} {lol3}
+              lol5 = {lol4} {lol4} {lol4} {lol4} {lol4} {lol4} {lol4} {lol4} {lol4} {lol4}
+              lol6 = {lol5} {lol5} {lol5} {lol5} {lol5} {lol5} {lol5} {lol5} {lol5} {lol5}
+              lol7 = {lol6} {lol6} {lol6} {lol6} {lol6} {lol6} {lol6} {lol6} {lol6} {lol6}
+              lol8 = {lol7} {lol7} {lol7} {lol7} {lol7} {lol7} {lol7} {lol7} {lol7} {lol7}
+              lol9 = {lol8} {lol8} {lol8} {lol8} {lol8} {lol8} {lol8} {lol8} {lol8} {lol8}
+              lolz = {lol9}
+        tests:
+          -
+            name: does not expand all placeables
+            asserts:
+              -
+                id: lolz
+                value: "{lol9}"
+                errors:
+                  -
+                    type: Cyclic


### PR DESCRIPTION
Added the million laughs bomb protection, and cleaned up a bit the `DisplayableNode` to handle all expressions.

That's needed because, in theory, the limit of string length may come not from message expansion, but maybe from function resolution, or some combination of different expressions.

Since we want to display a nice string replacement when possible, I need a generic `DisplayableNode` for when it is not.

The result is that for the million laughts bomb, we will display `{lol9}` rather than `{???}`, and if the string expansion would come from term, we'd show `{-lol9}` and so on, but if it would come from a `SelectExpression` which we don't know how to display as an error, we'd show `{???}`.

In the future we may add more inline expression error representations.

Perf looks good:

```
Zibis-MacBook-Pro:fluent-bundle (bomb)$ cargo bench
   Compiling fluent-bundle v0.7.1 (/Users/zbraniecki/projects/fluent/fluent-rs/fluent-bundle)
    Finished release [optimized] target(s) in 3.37s
     Running /Users/zbraniecki/projects/fluent/fluent-rs/target/release/deps/fluent_bundle-93ff50f9dceb0147

running 1 test
test types::tests::value_from_copy_ref ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

     Running /Users/zbraniecki/projects/fluent/fluent-rs/target/release/deps/resolver-cb6d5504b6b6a252
Gnuplot not found, disabling plotting
resolve/"simple"        time:   [6.0023 us 6.0434 us 6.0878 us]                              
                        change: [-2.9751% -1.5070% +0.0854%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
resolve/"preferences"   time:   [88.056 us 88.509 us 88.982 us]                                  
                        change: [-3.0768% -1.2458% +0.4298%] (p = 0.19 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
resolve/"menubar"       time:   [21.938 us 22.071 us 22.208 us]                               
                        change: [-4.3684% -3.0480% -1.5390%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
resolve/"unescape"      time:   [1.2433 us 1.2524 us 1.2612 us]                                
                        change: [-4.2747% -2.9488% -1.5070%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Gnuplot not found, disabling plotting
```