### PR TITLE
Fix doc links for FluentArgs

### DIFF
--- a/fluent-bundle/src/lib.rs
+++ b/fluent-bundle/src/lib.rs
@@ -76,7 +76,7 @@
 //! [`FluentBundle`]: ./bundle/struct.FluentBundle.html
 //! [`FluentResource`]: ./bundle/struct.FluentResource.html
 //! [`FluentMessage`]: ./bundle/struct.FluentMessage.html
-//! [`FluentArgs`]: ./bundle/struct.FluentArgs.html
+//! [`FluentArgs`]: ./bundle/type.FluentArgs.html
 //! [`FluentValue`]: ./bundle/struct.FluentValue.html
 
 #[macro_use]

--- a/fluent/src/lib.rs
+++ b/fluent/src/lib.rs
@@ -76,7 +76,7 @@
 //! [`FluentBundle`]: ./struct.FluentBundle.html
 //! [`FluentResource`]: ./struct.FluentResource.html
 //! [`FluentMessage`]: ./struct.FluentMessage.html
-//! [`FluentArgs`]: ./struct.FluentArgs.html
+//! [`FluentArgs`]: ./type.FluentArgs.html
 //! [`FluentValue`]: ./struct.FluentValue.html
 
 pub use fluent_bundle::*;


### PR DESCRIPTION
A couple outdated inter-doc links.