### PR TITLE
Switch FluentBundle to own its locale fallback chain

### DIFF
--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -18,21 +18,21 @@ keywords = ["localization", "l10n", "i18n", "intl", "internationalization"]
 categories = ["localization", "internationalization"]
 
 [dependencies]
-fluent-locale = "0.8"
+fluent-locale = { path = "../../fluent-locale-rs" }
 fluent-syntax = "0.9"
 failure = "0.1"
 failure_derive = "0.1"
 intl_pluralrules = "3.0"
 rental = "0.5.4"
 smallvec = "0.6.10"
-unic-langid = "0.5"
+unic-langid = { path = "../../../unic-locale/unic-langid" }
 
 [dev-dependencies]
 criterion = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 rand = "0.7.0"
-unic-langid = { version = "0.5", features = ["macros"] }
+unic-langid = { path = "../../../unic-locale/unic-langid", features = ["macros"] }
 
 [[bench]]
 name = "resolver"

--- a/fluent-bundle/examples/external_arguments.rs
+++ b/fluent-bundle/examples/external_arguments.rs
@@ -15,7 +15,7 @@ unread-emails =
     );
     let res = FluentResource::try_new(ftl_string).expect("Could not parse an FTL string.");
     let langid_en = langid!("en");
-    let mut bundle = FluentBundle::new(&[langid_en]);
+    let mut bundle = FluentBundle::new(vec![langid_en]);
     bundle
         .add_resource(res)
         .expect("Failed to add FTL resources to the bundle.");

--- a/fluent-bundle/examples/functions.rs
+++ b/fluent-bundle/examples/functions.rs
@@ -12,7 +12,7 @@ fn main() {
     let res3 = FluentResource::try_new(ftl_string3).expect("Could not parse an FTL string.");
 
     let langid_en_us = langid!("en-US");
-    let mut bundle = FluentBundle::new(&[langid_en_us]);
+    let mut bundle = FluentBundle::new(vec![langid_en_us]);
 
     // Test for a simple function that returns a string
     bundle

--- a/fluent-bundle/examples/simple-app.rs
+++ b/fluent-bundle/examples/simple-app.rs
@@ -102,7 +102,7 @@ fn main() {
 
     // 5. Create a new Fluent FluentBundle using the
     //    resolved locales.
-    let mut bundle = FluentBundle::new(resolved_locales.clone());
+    let mut bundle = FluentBundle::new(resolved_locales.iter().map(|l| l.to_owned().to_owned()).collect());
 
     // 6. Load the localization resource
     for path in L10N_RESOURCES {

--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -49,7 +49,7 @@ pub type FluentArgs<'args> = HashMap<&'args str, FluentValue<'args>>;
 ///     .expect("Could not parse an FTL string.");
 ///
 /// let langid_en = langid!("en-US");
-/// let mut bundle = FluentBundle::new(&[langid_en]);
+/// let mut bundle = FluentBundle::new(vec![langid_en]);
 ///
 /// bundle.add_resource(&resource)
 ///     .expect("Failed to add FTL resources to the bundle.");
@@ -145,29 +145,25 @@ impl<R> FluentBundle<R> {
     /// use unic_langid::langid;
     ///
     /// let langid_en = langid!("en-US");
-    /// let mut bundle: FluentBundle<FluentResource> = FluentBundle::new(&[langid_en]);
+    /// let mut bundle: FluentBundle<FluentResource> = FluentBundle::new(vec![langid_en]);
     /// ```
     ///
     /// # Errors
     ///
     /// This will panic if no formatters can be found for the locales.
-    pub fn new<'a, L: 'a + Into<LanguageIdentifier> + PartialEq + Clone>(
-        locales: impl IntoIterator<Item = &'a L>,
+    pub fn new<'a>(
+        locales: Vec<LanguageIdentifier>,
     ) -> Self {
-        let locales = locales
-            .into_iter()
-            .map(|s| s.clone().into())
-            .collect::<Vec<_>>();
         let default_langid = "en".parse().expect("Failed to parse `en` langid.");
+        let pr_locales = IntlPluralRules::get_locales(PluralRuleType::CARDINAL);
         let pr_locale = negotiate_languages(
             &locales,
-            &IntlPluralRules::get_locales(PluralRuleType::CARDINAL),
+            &pr_locales,
             Some(&default_langid),
             NegotiationStrategy::Lookup,
-        )[0]
-        .clone();
+        );
 
-        let pr = IntlPluralRules::create(pr_locale, PluralRuleType::CARDINAL)
+        let pr = IntlPluralRules::create(pr_locale[0].clone(), PluralRuleType::CARDINAL)
             .expect("Failed to initialize PluralRules.");
         FluentBundle {
             locales,
@@ -203,7 +199,7 @@ impl<R> FluentBundle<R> {
     /// let resource = FluentResource::try_new(ftl_string)
     ///     .expect("Could not parse an FTL string.");
     /// let langid_en = langid!("en-US");
-    /// let mut bundle = FluentBundle::new(&[langid_en]);
+    /// let mut bundle = FluentBundle::new(vec![langid_en]);
     /// bundle.add_resource(resource)
     ///     .expect("Failed to add FTL resources to the bundle.");
     /// assert_eq!(true, bundle.has_message("hello"));
@@ -312,7 +308,7 @@ impl<R> FluentBundle<R> {
     /// let resource = FluentResource::try_new(ftl_string)
     ///     .expect("Failed to parse an FTL string.");
     /// let langid_en = langid!("en-US");
-    /// let mut bundle = FluentBundle::new(&[langid_en]);
+    /// let mut bundle = FluentBundle::new(vec![langid_en]);
     /// bundle.add_resource(&resource)
     ///     .expect("Failed to add FTL resources to the bundle.");
     /// assert_eq!(true, bundle.has_message("hello"));
@@ -379,7 +375,7 @@ impl<R> FluentBundle<R> {
     /// let resource = FluentResource::try_new(ftl_string)
     ///     .expect("Could not parse an FTL string.");
     /// let langid_en = langid!("en-US");
-    /// let mut bundle = FluentBundle::new(&[langid_en]);
+    /// let mut bundle = FluentBundle::new(vec![langid_en]);
     /// bundle.add_resource(&resource)
     ///     .expect("Failed to add FTL resources to the bundle.");
     ///

--- a/fluent-bundle/src/lib.rs
+++ b/fluent-bundle/src/lib.rs
@@ -30,7 +30,7 @@
 //!     .expect("Failed to parse an FTL string.");
 //!
 //! let langid_en = langid!("en-US");
-//! let mut bundle = FluentBundle::new(&[langid_en]);
+//! let mut bundle = FluentBundle::new(vec![langid_en]);
 //!
 //! bundle
 //!     .add_resource(res)

--- a/fluent-bundle/tests/resolver_fixtures.rs
+++ b/fluent-bundle/tests/resolver_fixtures.rs
@@ -106,7 +106,7 @@ fn create_bundle(
                 .collect()
         })
         .expect("Failed to calculate locales.");
-    let mut bundle = FluentBundle::new(&locales);
+    let mut bundle = FluentBundle::new(locales);
     let use_isolating = b.and_then(|b| b.use_isolating).or_else(|| {
         defaults
             .as_ref()

--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -15,7 +15,7 @@ fn fluent_value_matches() {
     // We'll use `ars` locale since it happens to have all
     // plural rules categories.
     let langid_ars = langid!("ars");
-    let bundle: FluentBundle<FluentResource> = FluentBundle::new(&[langid_ars]);
+    let bundle: FluentBundle<FluentResource> = FluentBundle::new(vec![langid_ars]);
     let scope = Scope::new(&bundle, None);
 
     let string_val = FluentValue::String("string1".into());

--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -24,4 +24,4 @@ reiterate = "0.1.3"
 
 [dev-dependencies]
 elsa = "1.3.2"
-unic-langid = "0.5"
+unic-langid = { version = "0.5", features = ["macros"] }

--- a/fluent-fallback/examples/simple-fallback.rs
+++ b/fluent-fallback/examples/simple-fallback.rs
@@ -121,7 +121,7 @@ fn main() {
 
         iter::from_fn(move || {
             locales.next().map(|locale| {
-                let mut bundle = FluentBundle::new(vec![locale.clone()]);
+                let mut bundle = FluentBundle::new(vec![locale.to_owned().to_owned()]);
                 let res_path = res_path_scheme.replace("{locale}", &locale.to_string());
 
                 for res_id in &res_ids {

--- a/fluent-fallback/tests/localization_test.rs
+++ b/fluent-fallback/tests/localization_test.rs
@@ -28,7 +28,7 @@ fn localization_format() {
 
         iter::from_fn(move || {
             locales.next().map(|locale| {
-                let mut bundle = FluentBundle::new(vec![locale]);
+                let mut bundle = FluentBundle::new(vec![locale.to_owned()]);
                 let res_path = res_path_scheme.replace("{locale}", &locale.to_string());
 
                 for res_id in &res_ids {
@@ -70,7 +70,7 @@ fn localization_on_change() {
         let mut bundles = vec![];
 
         for locale in available_locales.borrow().iter() {
-            let mut bundle = FluentBundle::new(vec![locale]);
+            let mut bundle = FluentBundle::new(vec![locale.to_owned()]);
             let res_path = res_path_scheme.replace("{locale}", &locale.to_string());
             for res_id in res_ids {
                 let path = res_path.replace("{res_id}", res_id);

--- a/fluent-resmgr/src/resource_manager.rs
+++ b/fluent-resmgr/src/resource_manager.rs
@@ -44,9 +44,10 @@ impl ResourceManager {
         locales: Vec<LanguageIdentifier>,
         resource_ids: Vec<String>,
     ) -> FluentBundle<&FluentResource> {
-        let mut bundle = FluentBundle::new(&locales);
+        let primary_locale = locales.get(0).expect("Should have at least one locale.").to_string();
+        let mut bundle = FluentBundle::new(locales);
         for res_id in &resource_ids {
-            let res = self.get_resource(res_id, &locales[0].to_string());
+            let res = self.get_resource(res_id, &primary_locale);
             bundle.add_resource(res).unwrap();
         }
         bundle
@@ -63,7 +64,7 @@ impl ResourceManager {
         iter::from_fn(move || {
             locales.get(ptr).map(|locale| {
                 ptr += 1;
-                let mut bundle = FluentBundle::new(vec![locale]);
+                let mut bundle = FluentBundle::new(vec![locale.to_owned()]);
                 for res_id in &resource_ids {
                     let res = res_mgr.get_resource(&res_id, &locale.to_string());
                     bundle.add_resource(res).unwrap();


### PR DESCRIPTION
This is an attempt to use the new LangId/LanguageNegotiation/Intl/Fluent combination based on the current state of all the underlying crates.

I'm currently using `LanguageIdentifier` because it's more mature, but once it settles, we will want to store a fallback chain of `Locale` because the data from it will be used to inform intl formatters such as datetimeformat/numberformat and pluralrules which may use unicode extension keys.

Now, is that what we want? Is it a good design? Would it make sense to implement some type like `LocaleFallbackChain` that would be based on `Vec<Locale>`?

@cmyr - can you confirm that this looks how you'd expect based on https://github.com/projectfluent/fluent-locale-rs/pull/15 ?

Especially I'm curious about the `simple-app` example where we collect request locales from the user, available from the system, negotiate, and the push to localization.

My one concern is that we force `FluentBundle` to own, while it doesn't need anything but references, but forcing references would require lifetimes... Maybe `Vec<Cow<LanguageIdentifier>>`?
This would be particularly useful once we get to higher-level APIs like `Localization` in `fluent-fallback` where we get one list of locales, and we generate and re-generate FluentBundle's inside it - I think I'd prefer not to have to create a new `Languageidentifier` for each `FluentBundle`...