### PR TITLE
Add support for adding resources with overrides

### DIFF
--- a/fluent-bundle/tests/bundle.rs
+++ b/fluent-bundle/tests/bundle.rs
@@ -1,0 +1,37 @@
+use fluent_bundle::{FluentBundle, FluentResource};
+use unic_langid::LanguageIdentifier;
+
+#[test]
+fn add_resource_override() {
+    let res = FluentResource::try_new("key = Value".to_string()).unwrap();
+    let res2 = FluentResource::try_new("key = Value 2".to_string()).unwrap();
+
+    let en_us: LanguageIdentifier = "en-US"
+        .parse()
+        .expect("Failed to parse a language identifier");
+    let mut bundle = FluentBundle::<&FluentResource>::new(&[en_us]);
+
+    bundle.add_resource(&res).expect("Failed to add a resource");
+
+    assert!(bundle.add_resource(&res2).is_err());
+
+    let mut errors = vec![];
+
+    let value = bundle
+        .get_message("key")
+        .expect("Failed to retireve a message")
+        .value
+        .expect("Failed to retireve a value of a message");
+    assert_eq!(bundle.format_pattern(value, None, &mut errors), "Value");
+
+    bundle.add_resource_overriding(&res2);
+
+    let value = bundle
+        .get_message("key")
+        .expect("Failed to retireve a message")
+        .value
+        .expect("Failed to retireve a value of a message");
+    assert_eq!(bundle.format_pattern(value, None, &mut errors), "Value 2");
+
+    assert!(errors.is_empty());
+}


### PR DESCRIPTION
Fixes #142.

Stas, I'd like to get your r? mostly for the API decisions, in an effort to bring fluent-rs more into Fluent core realm.

The JS API relies heavily on default argument values for API ergonomics and in Rust we don't have the same luxury.

There are three options I can see using:

1) Required arguments:

```rust
impl FluentBundle {
    fn add_resource(&mut self, r: R, allow_overrides: bool) -> Result<()>;
}
```

2) Separate API:

```rust
impl FluentBundle {
    fn add_resource(&mut self, r: R, allow_overrides: bool) -> Result<()>;
    fn add_resource_with_overrides(&mut self, r: R);
}
```

3) Options bag with defaults:

```rust
#[derive(Default)]
struct FluentBundleAddResourceOptions {
    allow_overrides: bool
}

impl FluentBundle {
    fn add_resource(&mut self, r: R, options: FluentBundleAddResourceOptions) -> Result<()>;
}
```

allowing for:

```rust
bundle.add_resource(&res, FluentBundleAddResourceOptions::default());
```

or maybe even `Option<FluentBundleAddResourceOptions>` to allow for `add_resource(&res, None)`

or maybe even:

```rust
impl FluentBundle {
    fn add_resource(&mut self, r: R, options: FluentBundleAddResourcOptions) -> Result<()>;
    fn add_resource_with_defaults(&mut self, r: R) -> Result<()>;
}
```

========

My current approach, which is based on observation of how stdlib APIs are designed, but not really confirmed and may be just my interpretation is that I want to use (1) very rarely and only in cases where I believe the decision should be consciously made each and every time the API is used.
I use (2) for most cases where the defaults are sane and I expect them to be used most of the time, but I want to allow for alternative behavior.

I have never seen anyone doing (3) but it may be because we are still fairly early in the high-level APIs design, so maybe no standard model emerged yet.

One nice thing about (2) in *this particular* case is that it allows me to drop `Result` because the method becomes infallible, but for general design decisions that shouldn't be a main factor.