### PR TITLE
Intl memoizer use

### DIFF
--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -26,6 +26,7 @@ intl_pluralrules = "5.0"
 rental = "0.5"
 smallvec = "1.0"
 unic-langid = "0.7"
+intl-memoizer = { path = "../intl-memoizer" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/fluent-bundle/benches/resolver.rs
+++ b/fluent-bundle/benches/resolver.rs
@@ -8,6 +8,7 @@ use std::io::Read;
 
 use fluent_bundle::{FluentBundle, FluentResource, FluentValue};
 use fluent_syntax::ast;
+use unic_langid::langid;
 
 fn read_file(path: &str) -> Result<String, io::Error> {
     let mut f = File::open(path)?;
@@ -82,7 +83,8 @@ fn resolver_bench(c: &mut Criterion) {
             let res =
                 FluentResource::try_new(source.to_owned()).expect("Couldn't parse an FTL source");
             let ids = get_ids(&res);
-            let mut bundle = FluentBundle::default();
+            let lids = &[langid!("en")];
+            let mut bundle = FluentBundle::new(lids);
             bundle
                 .add_resource(res)
                 .expect("Couldn't add FluentResource to the FluentBundle");


### PR DESCRIPTION
@Manishearth - here's how I'd use the memoizer. One challenge I see is that there's no easy way to have a `Default` if I need to allocate an `IntlMemoizer` externally.

I'm wondering if it would be possible to have `FluentBundle` either take an external one or allocate its own if not provided, but I'm not sure how to design such a generic.