### PR TITLE
Add FluentValue::Custom

### DIFF
--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -445,7 +445,7 @@ impl<R> FluentBundle<R> {
         R: Borrow<FluentResource>,
     {
         let mut scope = Scope::new(self, args);
-        let result = pattern.resolve(&mut scope).to_string();
+        let result = pattern.resolve(&mut scope).as_string();
 
         for err in scope.errors {
             errors.push(err.into());

--- a/fluent-bundle/src/resolve.rs
+++ b/fluent-bundle/src/resolve.rs
@@ -25,7 +25,7 @@ pub enum ResolverError {
     Reference(String),
     MissingDefault,
     Cyclic,
-    TooManyPlaceables
+    TooManyPlaceables,
 }
 
 /// State for a single `ResolveValue::to_value` call.

--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -1,4 +1,5 @@
 use fluent_bundle::resolve::Scope;
+use fluent_bundle::types::FluentType;
 use fluent_bundle::FluentBundle;
 use fluent_bundle::FluentResource;
 use fluent_bundle::FluentValue;
@@ -73,4 +74,43 @@ fn fluent_value_from() {
 
     assert_eq!(value_f64, FluentValue::Number("23.5".into()));
     assert_eq!(value_isize, FluentValue::Number("-23".into()));
+}
+
+#[test]
+fn fluent_custom_type() {
+    #[derive(Debug, PartialEq)]
+    struct DateTime {
+        epoch: usize,
+    };
+
+    impl DateTime {
+        pub fn new(epoch: usize) -> Self {
+            Self { epoch }
+        }
+    }
+
+    impl FluentType for DateTime {
+        fn duplicate(&self) -> Box<dyn FluentType> {
+            Box::new(DateTime { epoch: self.epoch })
+        }
+        fn as_string(&self) -> std::borrow::Cow<'static, str> {
+            format!("{}", self.epoch).into()
+        }
+    }
+
+    impl std::fmt::Display for DateTime {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.epoch)
+        }
+    }
+
+    let dt = FluentValue::Custom(Box::new(DateTime::new(10)));
+    let dt2 = FluentValue::Custom(Box::new(DateTime::new(10)));
+    let dt3 = FluentValue::Custom(Box::new(DateTime::new(15)));
+
+    let sv = FluentValue::String("foo".into());
+
+    assert_eq!(dt == dt2, true);
+    assert_eq!(dt == dt3, false);
+    assert_eq!(dt == sv, false);
 }


### PR DESCRIPTION
Implements #146.

This is an implementation based on the dynamic dispatch approach suggested by @Manishearth .

There's an alternative approach using partial suggested by Lina - https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=ad520cb4f7ece7a41e01a9079bdf7901

I like it more, but unfortunately it turns `FluentValue` into a generic and requires a pretty painful conversion of the whole codebase to `FluentValue<A>` in tons of places.

@Manishearth - lmk what you think, and if you prefer the generic partial approach I can go refactor the code for it.