### PR TITLE
Support maximum_fraction_digits, and fix a panic on 32 bit systems

### DIFF
--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -154,3 +154,10 @@ fn fluent_number_to_operands() {
         }
     );
 }
+
+#[test]
+fn many_decimal_places() {
+    // this should not panic on an i32 system
+    let num = FluentNumber::new(2.813829837982735, FluentNumberOptions::default());
+    let _operands = PluralOperands::from(&num);
+}


### PR DESCRIPTION
Hi there,

Firstly, let me say thank you - I recently discovered Fluent, and it's a breath of fresh air after using gettext for a number of years. Thank you for all the thought and effort that has gone into it!

I had a user today report that our app was crashing when trying to render a translation with a floating point number. This turned out to be caused by an f64 with more than 9 decimal places - on a 32 bit system, it won't fit in a usize, so PluralOperands::try_from returns an error, and fluent-bundle .expect()s it not to.

The following patch adds support for maximum_fraction_digits, and caps it to 9 on 32 bit systems to ensure the usize won't overflow. I'm not sure if this is the best way to resolve the issue, but thought I'd share it in case it is useful.