### PR TITLE
Concurrent types

### DIFF
--- a/fluent-bundle/examples/custom_formatter.rs
+++ b/fluent-bundle/examples/custom_formatter.rs
@@ -2,15 +2,13 @@
 // to format selected types of values.
 //
 // This allows users to plug their own number formatter to Fluent.
-use std::sync::Mutex;
-
-use intl_memoizer::IntlLangMemoizer;
 use unic_langid::LanguageIdentifier;
 
-use fluent_bundle::types::{FluentNumber, FluentNumberOptions, FluentValue};
-use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
+use fluent_bundle::memoizer::MemoizerKind;
+use fluent_bundle::types::{FluentNumber, FluentNumberOptions};
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
 
-fn custom_formatter(num: &FluentValue, _intls: &Mutex<IntlLangMemoizer>) -> Option<String> {
+fn custom_formatter<M: MemoizerKind>(num: &FluentValue, _intls: &M) -> Option<String> {
     match num {
         FluentValue::Number(n) => Some(format!("CUSTOM({})", n.value).into()),
         _ => None,

--- a/fluent-bundle/examples/custom_type.rs
+++ b/fluent-bundle/examples/custom_type.rs
@@ -9,13 +9,11 @@
 // Lastly, we'll also create a new formatter which will be memoizable.
 //
 // The type and its options are modelled after ECMA402 Intl.DateTimeFormat.
-use std::sync::Mutex;
-
-use intl_memoizer::{IntlLangMemoizer, Memoizable};
+use intl_memoizer::Memoizable;
 use unic_langid::LanguageIdentifier;
 
-use fluent_bundle::types::{FluentType, FluentValue};
-use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
+use fluent_bundle::types::FluentType;
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
 
 // First we're going to define what options our new type is going to accept.
 // For the sake of the example, we're only going to allow two options:
@@ -107,14 +105,18 @@ impl FluentType for DateTime {
     fn duplicate(&self) -> Box<dyn FluentType> {
         Box::new(DateTime::new(self.epoch, DateTimeOptions::default()))
     }
-    fn as_string(&self, intls: &Mutex<IntlLangMemoizer>) -> std::borrow::Cow<'static, str> {
-        let mut intls = intls
-            .lock()
-            .expect("Failed to get rw lock on intl memoizer.");
-        let dtf = intls
-            .try_get::<DateTimeFormatter>((self.options.clone(),))
-            .expect("Failed to retrieve a formatter.");
-        dtf.format(self.epoch).into()
+    fn as_string(&self, intls: &intl_memoizer::IntlLangMemoizer) -> std::borrow::Cow<'static, str> {
+        intls
+            .with_try_get::<DateTimeFormatter, _, _>((self.options.clone(),), |dtf| {
+                dtf.format(self.epoch).into()
+            })
+            .expect("Failed to format a date.")
+    }
+    fn as_string_threadsafe(
+        &self,
+        _: &intl_memoizer::concurrent::IntlLangMemoizer,
+    ) -> std::borrow::Cow<'static, str> {
+        format!("2020-01-20 {}:00", self.epoch).into()
     }
 }
 

--- a/fluent-bundle/src/concurrent.rs
+++ b/fluent-bundle/src/concurrent.rs
@@ -1,0 +1,31 @@
+use intl_memoizer::{concurrent::IntlLangMemoizer, Memoizable};
+use unic_langid::LanguageIdentifier;
+
+use crate::bundle::FluentBundleBase;
+use crate::memoizer::MemoizerKind;
+use crate::types::FluentType;
+
+pub type FluentBundle<R> = FluentBundleBase<R, IntlLangMemoizer>;
+
+impl MemoizerKind for IntlLangMemoizer {
+    fn new(lang: LanguageIdentifier) -> Self
+    where
+        Self: Sized,
+    {
+        IntlLangMemoizer::new(lang)
+    }
+
+    fn with_try_get_threadsafe<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
+    where
+        Self: Sized,
+        I: Memoizable + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
+        U: FnOnce(&I) -> R,
+    {
+        self.with_try_get(args, cb)
+    }
+
+    fn stringify_value(&self, value: &dyn FluentType) -> std::borrow::Cow<'static, str> {
+        value.as_string_threadsafe(self)
+    }
+}

--- a/fluent-bundle/src/entry.rs
+++ b/fluent-bundle/src/entry.rs
@@ -4,7 +4,7 @@ use std::borrow::Borrow;
 
 use fluent_syntax::ast;
 
-use crate::bundle::{FluentArgs, FluentBundle};
+use crate::bundle::{FluentArgs, FluentBundleBase};
 use crate::resource::FluentResource;
 use crate::types::FluentValue;
 
@@ -23,7 +23,7 @@ pub trait GetEntry {
     fn get_entry_function(&self, id: &str) -> Option<&FluentFunction>;
 }
 
-impl<'bundle, R: Borrow<FluentResource>> GetEntry for FluentBundle<R> {
+impl<'bundle, R: Borrow<FluentResource>, M> GetEntry for FluentBundleBase<R, M> {
     fn get_entry_message(&self, id: &str) -> Option<&ast::Message> {
         self.entries.get(id).and_then(|entry| match *entry {
             Entry::Message(pos) => {

--- a/fluent-bundle/src/memoizer.rs
+++ b/fluent-bundle/src/memoizer.rs
@@ -1,0 +1,18 @@
+use crate::types::FluentType;
+use intl_memoizer::Memoizable;
+use unic_langid::LanguageIdentifier;
+
+pub trait MemoizerKind: 'static {
+    fn new(lang: LanguageIdentifier) -> Self
+    where
+        Self: Sized;
+
+    fn with_try_get_threadsafe<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
+    where
+        Self: Sized,
+        I: Memoizable + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
+        U: FnOnce(&I) -> R;
+
+    fn stringify_value(&self, value: &dyn FluentType) -> std::borrow::Cow<'static, str>;
+}

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -237,7 +237,7 @@ from_num!(f32 f64);
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::types::FluentValue;
 
     #[test]
     fn value_from_copy_ref() {

--- a/fluent-bundle/tests/custom_types.rs
+++ b/fluent-bundle/tests/custom_types.rs
@@ -1,10 +1,9 @@
+use fluent_bundle::memoizer::MemoizerKind;
 use fluent_bundle::types::FluentType;
 use fluent_bundle::FluentArgs;
 use fluent_bundle::FluentBundle;
 use fluent_bundle::FluentResource;
 use fluent_bundle::FluentValue;
-use intl_memoizer::IntlLangMemoizer;
-use std::sync::Mutex;
 use unic_langid::langid;
 
 #[test]
@@ -24,7 +23,13 @@ fn fluent_custom_type() {
         fn duplicate(&self) -> Box<dyn FluentType> {
             Box::new(DateTime { epoch: self.epoch })
         }
-        fn as_string(&self, _intls: &Mutex<IntlLangMemoizer>) -> std::borrow::Cow<'static, str> {
+        fn as_string(&self, _: &intl_memoizer::IntlLangMemoizer) -> std::borrow::Cow<'static, str> {
+            format!("{}", self.epoch).into()
+        }
+        fn as_string_threadsafe(
+            &self,
+            _: &intl_memoizer::concurrent::IntlLangMemoizer,
+        ) -> std::borrow::Cow<'static, str> {
             format!("{}", self.epoch).into()
         }
     }
@@ -115,7 +120,13 @@ fn fluent_date_time_builtin() {
         fn duplicate(&self) -> Box<dyn FluentType> {
             Box::new(DateTime::new(self.epoch, DateTimeOptions::default()))
         }
-        fn as_string(&self, _intls: &Mutex<IntlLangMemoizer>) -> std::borrow::Cow<'static, str> {
+        fn as_string(&self, _: &intl_memoizer::IntlLangMemoizer) -> std::borrow::Cow<'static, str> {
+            format!("2020-01-20 {}:00", self.epoch).into()
+        }
+        fn as_string_threadsafe(
+            &self,
+            _intls: &intl_memoizer::concurrent::IntlLangMemoizer,
+        ) -> std::borrow::Cow<'static, str> {
             format!("2020-01-20 {}:00", self.epoch).into()
         }
     }
@@ -171,7 +182,7 @@ key-ref = Hello { DATETIME($date, dateStyle: "full") } World
 
 #[test]
 fn fluent_custom_number_format() {
-    fn custom_formatter(num: &FluentValue, _intls: &Mutex<IntlLangMemoizer>) -> Option<String> {
+    fn custom_formatter<M: MemoizerKind>(num: &FluentValue, _intls: &M) -> Option<String> {
         match num {
             FluentValue::Number(_) => Some("CUSTOM".into()),
             _ => None,

--- a/intl-memoizer/examples/numberformat.rs
+++ b/intl-memoizer/examples/numberformat.rs
@@ -40,48 +40,39 @@ fn main() {
     {
         // Create an en-US memoizer
         let lang_memoizer = memoizer.get_for_lang(lang.clone());
-        {
-            let mut lang_memoizer2 = lang_memoizer.borrow_mut();
+        let options = NumberFormatOptions {
+            minimum_fraction_digits: 3,
+            maximum_fraction_digits: 5,
+        };
+        let result = lang_memoizer
+            .with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(2))
+            .unwrap();
 
-            let options = NumberFormatOptions {
-                minimum_fraction_digits: 3,
-                maximum_fraction_digits: 5,
-            };
-            let nf = lang_memoizer2.try_get::<NumberFormat>((options,)).unwrap();
-
-            assert_eq!(&nf.format(2), "en-US: 2, MFD: 3");
-        }
+        assert_eq!(&result, "en-US: 2, MFD: 3");
 
         // Reuse the same en-US memoizer
-        let lang_memoizer3 = memoizer.get_for_lang(lang.clone());
-        {
-            let mut lang_memoizer4 = lang_memoizer3.borrow_mut();
-
-            let options2 = NumberFormatOptions {
-                minimum_fraction_digits: 3,
-                maximum_fraction_digits: 5,
-            };
-            let nf2 = lang_memoizer4.try_get::<NumberFormat>((options2,)).unwrap();
-
-            assert_eq!(&nf2.format(2), "en-US: 2, MFD: 3");
-        }
-
-        // Memoizer gets dropped
+        let lang_memoizer = memoizer.get_for_lang(lang.clone());
+        let options = NumberFormatOptions {
+            minimum_fraction_digits: 3,
+            maximum_fraction_digits: 5,
+        };
+        let result = lang_memoizer
+            .with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(1))
+            .unwrap();
+        assert_eq!(&result, "en-US: 1, MFD: 3");
     }
 
     {
         // Here, we will construct a new lang memoizer
         let lang_memoizer = memoizer.get_for_lang(lang.clone());
-        {
-            let mut lang_memoizer2 = lang_memoizer.borrow_mut();
+        let options = NumberFormatOptions {
+            minimum_fraction_digits: 3,
+            maximum_fraction_digits: 5,
+        };
+        let result = lang_memoizer
+            .with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(7))
+            .unwrap();
 
-            let options = NumberFormatOptions {
-                minimum_fraction_digits: 3,
-                maximum_fraction_digits: 5,
-            };
-            let nf = lang_memoizer2.try_get::<NumberFormat>((options,)).unwrap();
-
-            assert_eq!(&nf.format(2), "en-US: 2, MFD: 3");
-        }
+        assert_eq!(&result, "en-US: 7, MFD: 3");
     }
 }

--- a/intl-memoizer/examples/pluralrules.rs
+++ b/intl-memoizer/examples/pluralrules.rs
@@ -23,11 +23,9 @@ fn main() {
 
     let lang: LanguageIdentifier = "en".parse().unwrap();
     let lang_memoizer = memoizer.get_for_lang(lang.clone());
-    let mut lang_memoizer_borrow = lang_memoizer.borrow_mut();
-
-    let pr = lang_memoizer_borrow
-        .try_get::<PluralRules>((PluralRuleType::CARDINAL,))
+    let result = lang_memoizer
+        .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |pr| pr.0.select(5))
         .unwrap();
 
-    assert_eq!(pr.0.select(5), Ok(PluralCategory::OTHER));
+    assert_eq!(result, Ok(PluralCategory::OTHER));
 }

--- a/intl-memoizer/src/concurrent.rs
+++ b/intl-memoizer/src/concurrent.rs
@@ -1,0 +1,39 @@
+use super::*;
+use std::sync::Mutex;
+
+#[derive(Debug)]
+pub struct IntlLangMemoizer {
+    lang: LanguageIdentifier,
+    map: Mutex<type_map::concurrent::TypeMap>,
+}
+
+impl IntlLangMemoizer {
+    pub fn new(lang: LanguageIdentifier) -> Self {
+        Self {
+            lang,
+            map: Mutex::new(type_map::concurrent::TypeMap::new()),
+        }
+    }
+
+    pub fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
+    where
+        Self: Sized,
+        I: Memoizable + Sync + Send + 'static,
+        I::Args: Send + Sync + 'static,
+        U: FnOnce(&I) -> R,
+    {
+        let mut map = self.map.lock().unwrap();
+        let cache = map
+            .entry::<HashMap<I::Args, I>>()
+            .or_insert_with(HashMap::new);
+
+        let e = match cache.entry(args.clone()) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let val = I::construct(self.lang.clone(), args)?;
+                entry.insert(val)
+            }
+        };
+        Ok(cb(&e))
+    }
+}


### PR DESCRIPTION
This patchset separates out `IntlMemoizer` and `concurrent::IntlMemoizer` and then `FluentBundle` and `concurrent::FluentBundle`.

This allows Gecko to use `FluentBundle` without `Mutex` (using `RefCell` instead), and all uses of `Send + Sync` will use `concurrent::FluentBundle`.