### PR TITLE
Implemented Clone for AST nodes

### DIFF
--- a/fluent-syntax/src/ast.rs
+++ b/fluent-syntax/src/ast.rs
@@ -1,22 +1,22 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Resource<'ast> {
     pub body: Vec<ResourceEntry<'ast>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ResourceEntry<'ast> {
     Entry(Entry<'ast>),
     Junk(&'ast str),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Entry<'ast> {
     Message(Message<'ast>),
     Term(Term<'ast>),
     Comment(Comment<'ast>),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Message<'ast> {
     pub id: Identifier<'ast>,
     pub value: Option<Pattern<'ast>>,
@@ -24,7 +24,7 @@ pub struct Message<'ast> {
     pub comment: Option<Comment<'ast>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Term<'ast> {
     pub id: Identifier<'ast>,
     pub value: Pattern<'ast>,
@@ -32,49 +32,49 @@ pub struct Term<'ast> {
     pub comment: Option<Comment<'ast>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Pattern<'ast> {
     pub elements: Vec<PatternElement<'ast>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PatternElement<'ast> {
     TextElement(&'ast str),
     Placeable(Expression<'ast>),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Attribute<'ast> {
     pub id: Identifier<'ast>,
     pub value: Pattern<'ast>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Identifier<'ast> {
     pub name: &'ast str,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Variant<'ast> {
     pub key: VariantKey<'ast>,
     pub value: Pattern<'ast>,
     pub default: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum VariantKey<'ast> {
     Identifier { name: &'ast str },
     NumberLiteral { value: &'ast str },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Comment<'ast> {
     Comment { content: Vec<&'ast str> },
     GroupComment { content: Vec<&'ast str> },
     ResourceComment { content: Vec<&'ast str> },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum InlineExpression<'ast> {
     StringLiteral {
         value: &'ast str,
@@ -103,19 +103,19 @@ pub enum InlineExpression<'ast> {
     },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CallArguments<'ast> {
     pub positional: Vec<InlineExpression<'ast>>,
     pub named: Vec<NamedArgument<'ast>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NamedArgument<'ast> {
     pub name: Identifier<'ast>,
     pub value: InlineExpression<'ast>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Expression<'ast> {
     InlineExpression(InlineExpression<'ast>),
     SelectExpression {


### PR DESCRIPTION
When implementing the code for rewriting parts of an AST, I noticed none of the AST types implement `Clone`.

Not having the impl means f you don't need to update a node and just want a copy of it, you have to implement the clone logic yourself instead of just writing `node.clone()`,

Is there any major reason why we don't `#[derive(Clone)]`?