### PR TITLE
Implement std::error::Error for ParserError

### DIFF
--- a/fluent-syntax/src/parser/errors.rs
+++ b/fluent-syntax/src/parser/errors.rs
@@ -1,8 +1,18 @@
+use std::fmt::{self, Display, Formatter};
+
 #[derive(Debug, PartialEq)]
 pub struct ParserError {
     pub pos: (usize, usize),
     pub slice: Option<(usize, usize)>,
     pub kind: ErrorKind,
+}
+
+impl std::error::Error for ParserError {}
+
+impl Display for ParserError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.kind, f)
+    }
 }
 
 macro_rules! error {
@@ -52,4 +62,69 @@ pub enum ErrorKind {
     UnbalancedClosingBrace,
     ExpectedInlineExpression,
     ExpectedSimpleExpressionAsSelector,
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ErrorKind::Generic => write!(f, "An error occurred"),
+            ErrorKind::ExpectedEntry => write!(f, "Expected an entry"),
+            ErrorKind::ExpectedToken(letter) => {
+                write!(f, "Expected a token starting with \"{}\"", letter)
+            }
+            ErrorKind::ExpectedCharRange { range } => write!(f, "Expected one of \"{}\"", range),
+            ErrorKind::ExpectedMessageField { entry_id } => {
+                write!(f, "Expected a message field for \"{}\"", entry_id)
+            }
+            ErrorKind::ExpectedTermField { entry_id } => {
+                write!(f, "Expected a term field for \"{}\"", entry_id)
+            }
+            ErrorKind::ForbiddenWhitespace => write!(f, "Whitespace is not allowed here"),
+            ErrorKind::ForbiddenCallee => write!(f, "Callee is not allowed here"),
+            ErrorKind::ForbiddenKey => write!(f, "Key is not allowed here"),
+            ErrorKind::MissingDefaultVariant => {
+                write!(f, "The select expression must have a default variant")
+            }
+            ErrorKind::MissingVariants => {
+                write!(f, "The select expression must have one or more variants")
+            }
+            ErrorKind::MissingValue => write!(f, "Expected a value"),
+            ErrorKind::MissingVariantKey => write!(f, "Expected a variant key"),
+            ErrorKind::MissingLiteral => write!(f, "Expected a literal"),
+            ErrorKind::MultipleDefaultVariants => {
+                write!(f, "A select expression can only have one default variant",)
+            }
+            ErrorKind::MessageReferenceAsSelector => {
+                write!(f, "Message references can't be used as a selector")
+            }
+            ErrorKind::TermReferenceAsSelector => {
+                write!(f, "Term references can't be used as a selector")
+            }
+            ErrorKind::MessageAttributeAsSelector => {
+                write!(f, "Message attributes can't be used as a selector")
+            }
+            ErrorKind::TermAttributeAsPlaceable => {
+                write!(f, "Term attributes can't be used as a placeable")
+            }
+            ErrorKind::UnterminatedStringExpression => write!(f, "Unterminated string expression"),
+            ErrorKind::PositionalArgumentFollowsNamed => {
+                write!(f, "Positional arguments must come before named arguments",)
+            }
+            ErrorKind::DuplicatedNamedArgument(name) => {
+                write!(f, "The \"{}\" argument appears twice", name)
+            }
+            ErrorKind::ForbiddenVariantAccessor => write!(f, "Forbidden variant accessor"),
+            ErrorKind::UnknownEscapeSequence(seq) => {
+                write!(f, "Unknown escape sequence, \"{}\"", seq)
+            }
+            ErrorKind::InvalidUnicodeEscapeSequence(seq) => {
+                write!(f, "Invalid unicode escape sequence, \"{}\"", seq)
+            }
+            ErrorKind::UnbalancedClosingBrace => write!(f, "Unbalanced closing brace"),
+            ErrorKind::ExpectedInlineExpression => write!(f, "Expected an inline expression"),
+            ErrorKind::ExpectedSimpleExpressionAsSelector => {
+                write!(f, "Expected a simple expression as selector")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Implementing `std::error::Error` and `Display` for `ParserError` can make handling parser errors and notifying the user a bit easier. I had to [implement my own](https://gitlab.com/wintech-engineering/fluent-machine-translations/-/blob/2cb4bdb3d035a855a5c0c1c16da20a388e523a83/cli/src/main.rs#L125-208) logic for this, and matching on each `ErrorKind` variant can be annoying.

I'm not sure if we want the `Display` impl to just show the reason parsing failed (i.e. defer to the `self.kind` impl), or whether we also want to mention `pos` in the error message. I believe `pos` represents the index into the string and not line/column numbers, so it's not very useful for a human wanting to fix the parse error.