### PR TITLE
Improve readability of accented pseudolocale

### DIFF
--- a/fluent-pseudo/src/lib.rs
+++ b/fluent-pseudo/src/lib.rs
@@ -74,7 +74,8 @@ pub fn transform(s: &str, flipped: bool, elongate: bool) -> Cow<str> {
         if cc >= 97 && cc <= 122 {
             let pos = cc - 97;
             let new_char = small_map[pos as usize];
-            if elongate && (cc == 97 || cc == 101 || cc == 105 || cc == 111 || cc == 117) {
+            // duplicate "a", "e", "o" and "u" to emulate ~30% longer text
+            if elongate && (cc == 97 || cc == 101 || cc == 111 || cc == 117) {
                 let mut s = new_char.to_string();
                 s.push(new_char);
                 s
@@ -116,7 +117,7 @@ mod tests {
         assert_eq!(x, "Ħeeŀŀoo <a>Ẇoořŀḓ</a>");
 
         let x = transform_dom("Hello <a>World</a> in <b>my</b> House.", false, true);
-        assert_eq!(x, "Ħeeŀŀoo <a>Ẇoořŀḓ</a> iiƞ <b>ḿẏ</b> Ħoouuşee.");
+        assert_eq!(x, "Ħeeŀŀoo <a>Ẇoořŀḓ</a> iƞ <b>ḿẏ</b> Ħoouuşee.");
 
         // Don't touch single character values.
         let x = transform_dom("f", false, true);

--- a/fluent-pseudo/src/lib.rs
+++ b/fluent-pseudo/src/lib.rs
@@ -3,12 +3,12 @@ use regex::Regex;
 use std::borrow::Cow;
 
 static TRANSFORM_SMALL_MAP: &[char] = &[
-    'ȧ', 'ƀ', 'ƈ', 'ḓ', 'ḗ', 'ƒ', 'ɠ', 'ħ', 'ī', 'ĵ', 'ķ', 'ŀ', 'ḿ', 'ƞ', 'ǿ', 'ƥ', 'ɋ', 'ř', 'ş',
-    'ŧ', 'ŭ', 'ṽ', 'ẇ', 'ẋ', 'ẏ', 'ẑ',
+    'a', 'ƀ', 'ƈ', 'ḓ', 'e', 'ƒ', 'ɠ', 'ħ', 'i', 'ĵ', 'ķ', 'ŀ', 'ḿ', 'ƞ', 'o', 'ƥ', 'ɋ', 'ř', 'ş',
+    'ŧ', 'u', 'ṽ', 'ẇ', 'ẋ', 'ẏ', 'ẑ',
 ];
 static TRANSFORM_CAPS_MAP: &[char] = &[
-    'Ȧ', 'Ɓ', 'Ƈ', 'Ḓ', 'Ḗ', 'Ƒ', 'Ɠ', 'Ħ', 'Ī', 'Ĵ', 'Ķ', 'Ŀ', 'Ḿ', 'Ƞ', 'Ǿ', 'Ƥ', 'Ɋ', 'Ř', 'Ş',
-    'Ŧ', 'Ŭ', 'Ṽ', 'Ẇ', 'Ẋ', 'Ẏ', 'Ẑ',
+    'A', 'Ɓ', 'Ƈ', 'Ḓ', 'E', 'Ƒ', 'Ɠ', 'Ħ', 'I', 'Ĵ', 'Ķ', 'Ŀ', 'Ḿ', 'Ƞ', 'O', 'Ƥ', 'Ɋ', 'Ř', 'Ş',
+    'Ŧ', 'U', 'Ṽ', 'Ẇ', 'Ẋ', 'Ẏ', 'Ẑ',
 ];
 
 static FLIPPED_SMALL_MAP: &[char] = &[
@@ -74,7 +74,7 @@ pub fn transform(s: &str, flipped: bool, elongate: bool) -> Cow<str> {
         if cc >= 97 && cc <= 122 {
             let pos = cc - 97;
             let new_char = small_map[pos as usize];
-            if elongate && (cc == 97 || cc == 101 || cc == 111 || cc == 117) {
+            if elongate && (cc == 97 || cc == 101 || cc == 105 || cc == 111 || cc == 117) {
                 let mut s = new_char.to_string();
                 s.push(new_char);
                 s
@@ -98,10 +98,10 @@ mod tests {
     #[test]
     fn it_works() {
         let x = transform("Hello World", false, true);
-        assert_eq!(x, "Ħḗḗŀŀǿǿ Ẇǿǿřŀḓ");
+        assert_eq!(x, "Ħeeŀŀoo Ẇoořŀḓ");
 
         let x = transform("Hello World", false, false);
-        assert_eq!(x, "Ħḗŀŀǿ Ẇǿřŀḓ");
+        assert_eq!(x, "Ħeŀŀo Ẇořŀḓ");
 
         let x = transform("Hello World", true, false);
         assert_eq!(x, "Hǝʅʅo Moɹʅp");
@@ -113,10 +113,10 @@ mod tests {
     #[test]
     fn dom_test() {
         let x = transform_dom("Hello <a>World</a>", false, true);
-        assert_eq!(x, "Ħḗḗŀŀǿǿ <a>Ẇǿǿřŀḓ</a>");
+        assert_eq!(x, "Ħeeŀŀoo <a>Ẇoořŀḓ</a>");
 
         let x = transform_dom("Hello <a>World</a> in <b>my</b> House.", false, true);
-        assert_eq!(x, "Ħḗḗŀŀǿǿ <a>Ẇǿǿřŀḓ</a> īƞ <b>ḿẏ</b> Ħǿǿŭŭşḗḗ.");
+        assert_eq!(x, "Ħeeŀŀoo <a>Ẇoořŀḓ</a> iiƞ <b>ḿẏ</b> Ħoouuşee.");
 
         // Don't touch single character values.
         let x = transform_dom("f", false, true);


### PR DESCRIPTION
This only applies accents to consonants to improve readability. It also adds
elongation for the letter 'i' which was missed previously.