### PR TITLE
Fix test expectations for test_pseudo

### DIFF
--- a/fluent/tests/pseudo.rs
+++ b/fluent/tests/pseudo.rs
@@ -29,6 +29,6 @@ fn test_pseudo() {
         let mut errors = vec![];
         let val = bundle.format_pattern(msg.value.unwrap(), None, &mut errors);
 
-        assert_eq!(val, "Ħḗḗŀŀǿǿ Ẇǿǿřŀḓ");
+        assert_eq!(val, "Ħeeŀŀoo Ẇoořŀḓ");
     }
 }


### PR DESCRIPTION
The behaviour changed as part of https://github.com/projectfluent/fluent-rs/pull/202
but this test was not updated.