### PR TITLE
Add License Files to Crates

### DIFF
--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -20,7 +20,9 @@ include = [
 	"src/**/*",
 	"benches/*.rs",
 	"Cargo.toml",
-	"README.md"
+	"README.md",
+	"LICENSE-APACHE",
+	"LICENSE-MIT"
 ]
 
 [dependencies]

--- a/fluent-bundle/LICENSE-APACHE
+++ b/fluent-bundle/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fluent-bundle/LICENSE-MIT
+++ b/fluent-bundle/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/fluent-cli/LICENSE-APACHE
+++ b/fluent-cli/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fluent-cli/LICENSE-MIT
+++ b/fluent-cli/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/fluent-fallback/LICENSE-APACHE
+++ b/fluent-fallback/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fluent-fallback/LICENSE-MIT
+++ b/fluent-fallback/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/fluent-pseudo/Cargo.toml
+++ b/fluent-pseudo/Cargo.toml
@@ -19,7 +19,9 @@ include = [
 	"src/**/*",
 	"benches/*.rs",
 	"Cargo.toml",
-	"README.md"
+	"README.md",
+	"LICENSE-APACHE",
+	"LICENSE-MIT"
 ]
 
 [dependencies]

--- a/fluent-pseudo/LICENSE-APACHE
+++ b/fluent-pseudo/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fluent-pseudo/LICENSE-MIT
+++ b/fluent-pseudo/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/fluent-resmgr/LICENSE-APACHE
+++ b/fluent-resmgr/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fluent-resmgr/LICENSE-MIT
+++ b/fluent-resmgr/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/fluent-syntax/Cargo.toml
+++ b/fluent-syntax/Cargo.toml
@@ -19,7 +19,9 @@ include = [
 	"src/**/*",
 	"benches/*.rs",
 	"Cargo.toml",
-	"README.md"
+	"README.md",
+	"LICENSE-APACHE",
+	"LICENSE-MIT"
 ]
 
 [dependencies]

--- a/fluent-syntax/LICENSE-APACHE
+++ b/fluent-syntax/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fluent-syntax/LICENSE-MIT
+++ b/fluent-syntax/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/fluent/Cargo.toml
+++ b/fluent/Cargo.toml
@@ -20,7 +20,9 @@ include = [
 	"src/**/*",
 	"benches/*.rs",
 	"Cargo.toml",
-	"README.md"
+	"README.md",
+	"LICENSE-APACHE",
+	"LICENSE-MIT"
 ]
 
 [dependencies]

--- a/fluent/LICENSE-APACHE
+++ b/fluent/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fluent/LICENSE-MIT
+++ b/fluent/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/intl-memoizer/Cargo.toml
+++ b/intl-memoizer/Cargo.toml
@@ -20,7 +20,9 @@ include = [
 	"src/**/*",
 	"benches/*.rs",
 	"Cargo.toml",
-	"README.md"
+	"README.md",
+	"LICENSE-APACHE",
+	"LICENSE-MIT"
 ]
 
 [dependencies]

--- a/intl-memoizer/LICENSE-APACHE
+++ b/intl-memoizer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/intl-memoizer/LICENSE-MIT
+++ b/intl-memoizer/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This PR adds the two possible licenses file to all published crates. This would ease to compile a list of all licenses and corresponding files for packages which depend on `projectfluent` rust crates. `cargo` does not support mutiple license files therefore links are used see related PR for `cargo` (https://github.com/rust-lang/cargo/issues/3537). I would be glad to receive some feedback and/or review. 