### PR TITLE
Fix useGrouping in fluent-bundle

### DIFF
--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -98,6 +98,9 @@ impl FluentNumberOptions {
                 ("currencyDisplay", FluentValue::String(n)) => {
                     self.currency_display = n.as_ref().into();
                 }
+                ("useGrouping", FluentValue::String(n)) => {
+                    self.use_grouping = n != "false";
+                }
                 ("minimumIntegerDigits", FluentValue::Number(n)) => {
                     self.minimum_integer_digits = Some(n.into());
                 }

--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -107,7 +107,7 @@ fn fluent_number_style() {
     args.add("style", "currency".into());
     args.add("currency", "EUR".into());
     args.add("currencyDisplay", "code".into());
-    args.add("useGrouping", "true".into());
+    args.add("useGrouping", "false".into());
     args.add("minimumIntegerDigits", 3.into());
     args.add("minimumFractionDigits", 3.into());
     args.add("maximumFractionDigits", 8.into());
@@ -120,7 +120,7 @@ fn fluent_number_style() {
     assert_eq!(fno.style, FluentNumberStyle::Currency);
     assert_eq!(fno.currency, Some("EUR".to_string()));
     assert_eq!(fno.currency_display, FluentNumberCurrencyDisplayStyle::Code);
-    assert_eq!(fno.use_grouping, true);
+    assert_eq!(fno.use_grouping, false);
 
     let num = FluentNumber::new(0.2, FluentNumberOptions::default());
     assert_eq!(num.as_string(), "0.2");


### PR DESCRIPTION
The `useGrouping` number option is assigned a default value, but never updated.
In the Intl.NumberFormat API, `useGrouping` is a boolean. Since Fluent does not
support boolean values, a string is used here instead. If the value is `"false"`,
grouping is disabled, otherwise it is enabled.

This was missed because the unit tests tested for `"true"`, which is the default
value for useGrouping.