### PR TITLE
Use FxHash for faster entry hashing

### DIFF
--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -33,6 +33,7 @@ ouroboros = "0.7"
 smallvec = "1"
 unic-langid = "0.9"
 intl-memoizer = { version = "0.5", path = "../intl-memoizer" }
+rustc-hash = "1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -6,7 +6,8 @@
 
 use std::borrow::Borrow;
 use std::borrow::Cow;
-use std::collections::hash_map::{Entry as HashEntry, HashMap};
+use rustc_hash::FxHashMap;
+use std::collections::hash_map::Entry as HashEntry;
 use std::default::Default;
 use std::fmt;
 
@@ -31,7 +32,7 @@ use crate::types::FluentValue;
 pub struct FluentBundleBase<R, M> {
     pub locales: Vec<LanguageIdentifier>,
     pub(crate) resources: Vec<R>,
-    pub(crate) entries: HashMap<String, Entry>,
+    pub(crate) entries: FxHashMap<String, Entry>,
     pub(crate) intls: M,
     pub(crate) use_isolating: bool,
     pub(crate) transform: Option<fn(&str) -> Cow<str>>,
@@ -64,7 +65,7 @@ impl<R, M: MemoizerKind> FluentBundleBase<R, M> {
         Self {
             locales,
             resources: vec![],
-            entries: HashMap::new(),
+            entries: FxHashMap::default(),
             intls: M::new(first_locale),
             use_isolating: true,
             transform: None,


### PR DESCRIPTION
Welp, this yields some impressive improvements:

construction of `FluentBundle`:

```
     Running /projects/fluent-rs/target/release/deps/resolver-86bf677ee94bafa5
Gnuplot not found, using plotters backend
construct/simple        time:   [7.0816 us 7.0940 us 7.1062 us]                              
                        change: [-16.304% -16.104% -15.903%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
construct/preferences   time:   [32.511 us 32.715 us 33.003 us]                                   
                        change: [-27.000% -26.691% -26.300%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
construct/menubar       time:   [8.5587 us 8.5777 us 8.5967 us]                               
                        change: [-27.616% -27.393% -27.140%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
construct/unescape      time:   [380.74 ns 381.36 ns 382.10 ns]                               
                        change: [-17.756% -17.576% -17.410%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```

Resolution of messages:
```
     Running /projects/fluent-rs/target/release/deps/resolver-86bf677ee94bafa5
Gnuplot not found, using plotters backend
resolve/simple          time:   [3.3057 us 3.3115 us 3.3178 us]                            
                        change: [-14.753% -13.568% -12.828%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
resolve/preferences     time:   [27.958 us 28.015 us 28.074 us]                                 
                        change: [-12.324% -12.112% -11.927%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
resolve/menubar         time:   [6.8051 us 6.8246 us 6.8471 us]                             
                        change: [-13.146% -12.851% -12.567%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
resolve/unescape        time:   [417.40 ns 417.93 ns 418.50 ns]                             
                        change: [-9.8769% -9.6303% -9.3868%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe

resolve_to_str/simple   time:   [3.2104 us 3.2134 us 3.2166 us]                                   
                        change: [-17.350% -17.137% -16.937%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
resolve_to_str/preferences                                                                             
                        time:   [33.752 us 33.795 us 33.841 us]
                        change: [-12.678% -12.493% -12.294%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
resolve_to_str/menubar  time:   [6.9652 us 6.9717 us 6.9788 us]                                    
                        change: [-9.8398% -9.5565% -9.2834%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
resolve_to_str/unescape time:   [462.41 ns 463.98 ns 465.85 ns]                                    
                        change: [-8.3773% -7.9934% -7.6357%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high severe

```