### PR TITLE
Mock test for issue #213

### DIFF
--- a/fluent-syntax/.gitattributes
+++ b/fluent-syntax/.gitattributes
@@ -1,2 +1,3 @@
 tests/fixtures/crlf.ftl eol=crlf
+tests/fixtures/crlf-issue213.ftl eol=crlf
 tests/fixtures/cr.ftl eol=cr

--- a/fluent-syntax/tests/fixtures/crlf-issue213.ftl
+++ b/fluent-syntax/tests/fixtures/crlf-issue213.ftl
@@ -1,0 +1,8 @@
+multiline-message-indented-breaks = 
+    This is a multiline message 1.
+    
+    This is a multiline message 2.
+multiline-message = 
+    This is a multiline message 1.
+
+    This is a multiline message 2.

--- a/fluent-syntax/tests/fixtures/crlf-issue213.json
+++ b/fluent-syntax/tests/fixtures/crlf-issue213.json
@@ -1,0 +1,65 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "multiline-message-indented-breaks"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "This is a multiline message 1."
+                    },
+                    {
+                        "type": "TextElement",
+                        "value": "\n"
+                    },
+                    {
+                        "type": "TextElement",
+                        "value": "\n"
+                    },
+                    {
+                        "type": "TextElement",
+                        "value": "This is a multiline message 2."
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "multiline-message"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "This is a multiline message 1."
+                    },
+                    {
+                        "type": "TextElement",
+                        "value": "\n"
+                    },
+                    {
+                        "type": "TextElement",
+                        "value": "\n"
+                    },
+                    {
+                        "type": "TextElement",
+                        "value": "This is a multiline message 2."
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        }
+    ]
+}

--- a/fluent-syntax/tests/parser_fixtures.rs
+++ b/fluent-syntax/tests/parser_fixtures.rs
@@ -45,7 +45,7 @@ fn parse_fixtures_compare() {
             serde_json::from_str(reference_file.as_str()).unwrap();
         adapt_ast(&mut ref_ast);
 
-        assert_eq!(target_ast.body.len(), ref_ast.body.len());
+        // assert_eq!(target_ast.body.len(), ref_ast.body.len());
         for (entry, ref_entry) in target_ast.body.iter().zip(ref_ast.body.iter()) {
             assert_eq!(entry, ref_entry);
         }


### PR DESCRIPTION
This isn't a sound way to hook up this test, as it taints the upstream reference fixtures.

But I guess it'd be good way to give #213 a boost.

FWIW, I ran the `crlf.ftl` test locally, and it produced the expected results, though the tests fail.

This test fails in an unexpected way, in that it's not the `TextElement` that's segmented differently, but that the continuation isn't detected.