### PR TITLE
Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent [![Build Status](https://travis-ci.org/projectfluent/fluent-rs.svg?branch=master)](https://travis-ci.org/projectfluent/fluent-rs) [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
+# Fluent ![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 `fluent-rs` is a collection of Rust crates implementing [Project Fluent](https://projectfluent.org).
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# Fluent ![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
+# Fluent [![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)](https://github.com/projectfluent/fluent-rs/actions?query=branch%3Amaster+workflow%3A%22Build+and+test%22) [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 `fluent-rs` is a collection of Rust crates implementing [Project Fluent](https://projectfluent.org).
 
 The crates perform the following functions:
 
-## fluent [![crates.io](http://meritbadge.herokuapp.com/fluent)](https://crates.io/crates/fluent)
+## fluent [![crates.io](https://meritbadge.herokuapp.com/fluent)](https://crates.io/crates/fluent)
 
 Umbrella crate combining crates that are ready to be used in production.
 
-## fluent-syntax [![crates.io](http://meritbadge.herokuapp.com/fluent_syntax)](https://crates.io/crates/fluent_syntax)
+## fluent-syntax [![crates.io](https://meritbadge.herokuapp.com/fluent_syntax)](https://crates.io/crates/fluent_syntax)
 
 Low level Fluent Syntax AST and parser API.
 
-## fluent-bundle [![crates.io](http://meritbadge.herokuapp.com/fluent_bundle)](https://crates.io/crates/fluent_bundle)
+## fluent-bundle [![crates.io](https://meritbadge.herokuapp.com/fluent_bundle)](https://crates.io/crates/fluent_bundle)
 
 Implementation of the low-level Fluent Localization System providing localization capabilities for any Rust project.
 
-## fluent-fallback [![crates.io](http://meritbadge.herokuapp.com/fluent_fallback)](https://crates.io/crates/fluent_fallback)
+## fluent-fallback [![crates.io](https://meritbadge.herokuapp.com/fluent_fallback)](https://crates.io/crates/fluent_fallback)
 
 Implementation of the high-level Fluent Localization System providing localization capabilities for any Rust project.
 
-## fluent-resmgr [![crates.io](http://meritbadge.herokuapp.com/fluent_resmgr)](https://crates.io/crates/fluent_resmgr)
+## fluent-resmgr [![crates.io](https://meritbadge.herokuapp.com/fluent_resmgr)](https://crates.io/crates/fluent_resmgr)
 
 Resource Manager for localization resources.
 
-## fluent-cli [![crates.io](http://meritbadge.herokuapp.com/fluent_cli)](https://crates.io/crates/fluent_cli)
+## fluent-cli
 
 Collection of command line tools for Fluent.

--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -4,8 +4,8 @@
 framework designed to unleash the entire expressive power of natural language
 translations.
 
-[![crates.io](http://meritbadge.herokuapp.com/fluent-bundle)](https://crates.io/crates/fluent-bundle)
-![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
+[![crates.io](https://meritbadge.herokuapp.com/fluent-bundle)](https://crates.io/crates/fluent-bundle)
+[![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)](https://github.com/projectfluent/fluent-rs/actions?query=branch%3Amaster+workflow%3A%22Build+and+test%22)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Project Fluent keeps simple things simple and makes complex things possible.

--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -4,8 +4,8 @@
 framework designed to unleash the entire expressive power of natural language
 translations.
 
-[![crates.io](http://meritbadge.herokuapp.com/fluent)](https://crates.io/crates/fluent)
-[![Build Status](https://travis-ci.org/projectfluent/fluent-rs.svg?branch=master)](https://travis-ci.org/projectfluent/fluent-rs)
+[![crates.io](http://meritbadge.herokuapp.com/fluent-bundle)](https://crates.io/crates/fluent-bundle)
+![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Project Fluent keeps simple things simple and makes complex things possible.

--- a/fluent-fallback/README.md
+++ b/fluent-fallback/README.md
@@ -9,7 +9,7 @@ the corresponding UI, reacting to events such as locale changes, resource update
 The API can be used directly, or can serve as an example of state manager for `fluent-bundle` and `fluent-resmgr`. 
 
 [![crates.io](http://meritbadge.herokuapp.com/fluent-fallback)](https://crates.io/crates/fluent-fallback)
-[![Build Status](https://travis-ci.org/projectfluent/fluent-rs.svg?branch=master)](https://travis-ci.org/projectfluent/fluent-rs)
+![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Project Fluent keeps simple things simple and makes complex things possible.

--- a/fluent-fallback/README.md
+++ b/fluent-fallback/README.md
@@ -8,8 +8,8 @@ the corresponding UI, reacting to events such as locale changes, resource update
 
 The API can be used directly, or can serve as an example of state manager for `fluent-bundle` and `fluent-resmgr`. 
 
-[![crates.io](http://meritbadge.herokuapp.com/fluent-fallback)](https://crates.io/crates/fluent-fallback)
-![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
+[![crates.io](https://meritbadge.herokuapp.com/fluent-fallback)](https://crates.io/crates/fluent-fallback)
+[![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)](https://github.com/projectfluent/fluent-rs/actions?query=branch%3Amaster+workflow%3A%22Build+and+test%22)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Project Fluent keeps simple things simple and makes complex things possible.

--- a/fluent-pseudo/README.md
+++ b/fluent-pseudo/README.md
@@ -5,7 +5,7 @@ framework designed to unleash the entire expressive power of natural language
 translations.
 
 [![crates.io](http://meritbadge.herokuapp.com/fluent-pseudo)](https://crates.io/crates/fluent-pseudo)
-[![Build Status](https://travis-ci.org/projectfluent/fluent-rs.svg?branch=master)](https://travis-ci.org/projectfluent/fluent-rs)
+![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Usage

--- a/fluent-pseudo/README.md
+++ b/fluent-pseudo/README.md
@@ -4,8 +4,8 @@
 framework designed to unleash the entire expressive power of natural language
 translations.
 
-[![crates.io](http://meritbadge.herokuapp.com/fluent-pseudo)](https://crates.io/crates/fluent-pseudo)
-![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
+[![crates.io](https://meritbadge.herokuapp.com/fluent-pseudo)](https://crates.io/crates/fluent-pseudo)
+[![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)](https://github.com/projectfluent/fluent-rs/actions?query=branch%3Amaster+workflow%3A%22Build+and+test%22)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Usage

--- a/fluent-resmgr/README.md
+++ b/fluent-resmgr/README.md
@@ -6,7 +6,7 @@ Resource Manager provides a standalone solution for managing localization resour
 can be used by `fluent-fallback` or other higher level bindings.
 
 [![crates.io](http://meritbadge.herokuapp.com/fluent-resmgr)](https://crates.io/crates/fluent-resmgr)
-[![Build Status](https://travis-ci.org/projectfluent/fluent-rs.svg?branch=master)](https://travis-ci.org/projectfluent/fluent-rs)
+![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Project Fluent keeps simple things simple and makes complex things possible.

--- a/fluent-resmgr/README.md
+++ b/fluent-resmgr/README.md
@@ -5,8 +5,8 @@
 Resource Manager provides a standalone solution for managing localization resources which
 can be used by `fluent-fallback` or other higher level bindings.
 
-[![crates.io](http://meritbadge.herokuapp.com/fluent-resmgr)](https://crates.io/crates/fluent-resmgr)
-![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
+[![crates.io](https://meritbadge.herokuapp.com/fluent-resmgr)](https://crates.io/crates/fluent-resmgr)
+[![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)](https://github.com/projectfluent/fluent-rs/actions?query=branch%3Amaster+workflow%3A%22Build+and+test%22)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Project Fluent keeps simple things simple and makes complex things possible.

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -3,8 +3,8 @@
 `fluent-syntax` is a parser/serializer API for the Fluent Syntax, part of the [Project Fluent](https://projectfluent.org/), a localization
 framework designed to unleash the entire expressive power of natural language translations.
 
-[![crates.io](http://meritbadge.herokuapp.com/fluent-syntax)](https://crates.io/crates/fluent-syntax)
-![Build Status]https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
+[![crates.io](https://meritbadge.herokuapp.com/fluent-syntax)](https://crates.io/crates/fluent-syntax)
+[![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)](https://github.com/projectfluent/fluent-rs/actions?query=branch%3Amaster+workflow%3A%22Build+and+test%22)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Status

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -4,7 +4,7 @@
 framework designed to unleash the entire expressive power of natural language translations.
 
 [![crates.io](http://meritbadge.herokuapp.com/fluent-syntax)](https://crates.io/crates/fluent-syntax)
-[![Build Status](https://travis-ci.org/projectfluent/fluent-rs.svg?branch=master)](https://travis-ci.org/projectfluent/fluent-rs)
+![Build Status]https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Status

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -4,8 +4,8 @@
 framework designed to unleash the entire expressive power of natural language
 translations.
 
-[![crates.io](http://meritbadge.herokuapp.com/fluent)](https://crates.io/crates/fluent)
-![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
+[![crates.io](https://meritbadge.herokuapp.com/fluent)](https://crates.io/crates/fluent)
+[![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)](https://github.com/projectfluent/fluent-rs/actions?query=branch%3Amaster+workflow%3A%22Build+and+test%22)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Project Fluent keeps simple things simple and makes complex things possible.

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -5,7 +5,7 @@ framework designed to unleash the entire expressive power of natural language
 translations.
 
 [![crates.io](http://meritbadge.herokuapp.com/fluent)](https://crates.io/crates/fluent)
-[![Build Status](https://travis-ci.org/projectfluent/fluent-rs.svg?branch=master)](https://travis-ci.org/projectfluent/fluent-rs)
+![Build and test](https://github.com/projectfluent/fluent-rs/workflows/Build%20and%20test/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=master)](https://coveralls.io/github/projectfluent/fluent-rs?branch=master)
 
 Project Fluent keeps simple things simple and makes complex things possible.


### PR DESCRIPTION
The badges in the readme are still pointing to travis.

Fixing https for meritbadge as a fly-by, to make the badges work in vscode preview. Also dropping the badge for `fluent-cli` as that's not on crates.io