### PR TITLE
Replace ouroboros with self_cell

### DIFF
--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -29,11 +29,11 @@ include = [
 fluent-langneg = "0.13"
 fluent-syntax = { version = "0.11", path = "../fluent-syntax" }
 intl_pluralrules = "7.0.1"
-ouroboros = "0.9"
-smallvec = "1"
-unic-langid = "0.9"
 intl-memoizer = { version = "0.5", path = "../intl-memoizer" }
 rustc-hash = "1"
+self_cell = "0.9"
+smallvec = "1"
+unic-langid = "0.9"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/fluent-bundle/src/resource.rs
+++ b/fluent-bundle/src/resource.rs
@@ -1,15 +1,20 @@
 use fluent_syntax::ast;
 use fluent_syntax::parser::{parse_runtime, ParserError};
-use ouroboros::self_referencing;
 
-#[self_referencing]
-#[derive(Debug)]
-pub struct InnerFluentResource {
-    string: String,
-    #[borrows(string)]
-    #[covariant]
-    ast: ast::Resource<&'this str>,
-}
+use self_cell::self_cell;
+
+type Resource<'s> = ast::Resource<&'s str>;
+
+self_cell!(
+    pub struct InnerFluentResource {
+        owner: String,
+
+        #[covariant]
+        dependent: Resource,
+    }
+
+    impl {Debug}
+);
 
 /// A resource containing a list of localization messages.
 ///
@@ -77,22 +82,17 @@ impl FluentResource {
     pub fn try_new(source: String) -> Result<Self, (Self, Vec<ParserError>)> {
         let mut errors = None;
 
-        let res = InnerFluentResourceBuilder {
-            string: source,
-            ast_builder: |string: &str| match parse_runtime(string) {
-                Ok(ast) => ast,
-                Err((ast, err)) => {
-                    errors = Some(err);
-                    ast
-                }
-            },
-        }
-        .build();
+        let res = InnerFluentResource::new(source, |source| match parse_runtime(source.as_str()) {
+            Ok(ast) => ast,
+            Err((ast, err)) => {
+                errors = Some(err);
+                ast
+            }
+        });
 
-        if let Some(errors) = errors {
-            Err((Self(res), errors))
-        } else {
-            Ok(Self(res))
+        match errors {
+            None => Ok(Self(res)),
+            Some(err) => Err((Self(res), err)),
         }
     }
 
@@ -115,7 +115,7 @@ impl FluentResource {
     /// );
     /// ```
     pub fn source(&self) -> &str {
-        &self.0.borrow_string()
+        &self.0.borrow_owner()
     }
 
     /// Returns an iterator over [`entries`](fluent_syntax::ast::Entry) of the [`FluentResource`].
@@ -142,7 +142,7 @@ impl FluentResource {
     /// assert!(matches!(resource.entries().next(), Some(ast::Entry::Message(_))));
     /// ```
     pub fn entries(&self) -> impl Iterator<Item = &ast::Entry<&str>> {
-        self.0.borrow_ast().body.iter()
+        self.0.borrow_dependent().body.iter()
     }
 
     /// Returns an [`Entry`](fluent_syntax::ast::Entry) at the
@@ -166,6 +166,6 @@ impl FluentResource {
     /// assert!(matches!(resource.get_entry(0), Some(ast::Entry::Message(_))));
     /// ```
     pub fn get_entry(&self, idx: usize) -> Option<&ast::Entry<&str>> {
-        self.0.borrow_ast().body.get(idx)
+        self.0.borrow_dependent().body.get(idx)
     }
 }


### PR DESCRIPTION
Before (fluent-bundle):

$ cargo build
... 37 dependencies
Finished dev [unoptimized + debuginfo] target(s) in 18.39s

After:

$ cargo build
... 27 dependencies
Finished dev [unoptimized + debuginfo] target(s) in 14.59s

That's 26% faster in this very rough test. But the 10 fewer dependencies make this seem plausible. There are still some proc-macro dependencies like syn left, but they have nothing to do with `self_cell` as it has 0 dependencies and doesn't use proc-macros.

Disclaimer I'm the author of `self_cell`.

I ran `cargo test` and all non skipped tests passed before and after.

This is a continuation of https://github.com/projectfluent/fluent-rs/pull/221 which seems to have become stale.

I also ran the iai benchmarks:

Before:

```
iai_resolve_preferences
Instructions:             1875919 (No change)
L1 Accesses:              2669397 (No change)
L2 Accesses:                 9929 (No change)
RAM Accesses:                6519 (No change)
Estimated Cycles:         2947207 (No change)
```

After:

```
iai_resolve_preferences
Instructions:             1873556 (-0.125965%)
L1 Accesses:              2667079 (-0.086836%)
L2 Accesses:                 9848 (-0.815792%)
RAM Accesses:                6516 (-0.046019%)
Estimated Cycles:         2944379 (-0.095955%)
```

And it's slightly faster than ouroboros.