### PR TITLE
Bug 1491867: Bump version to 0.3.0 since it changes the public API

### DIFF
--- a/fluent-pseudo/CHANGELOG.md
+++ b/fluent-pseudo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
   - …
 
-## fluent-pseudo 0.2.4 (July 19, 2021)
+## fluent-pseudo 0.3.0 (July 19, 2021)
   - Ability to wrap strings in markers.
 
 ## fluent-pseudo 0.2.3 (November 12, 2020)

--- a/fluent-pseudo/Cargo.toml
+++ b/fluent-pseudo/Cargo.toml
@@ -3,7 +3,7 @@ name = "fluent-pseudo"
 description = """
 Pseudolocalization transformation API for use with Project Fluent API.
 """
-version = "0.2.4"
+version = "0.3.0"
 edition = "2018"
 authors = [
     "Zibi Braniecki <gandalf@mozilla.com>",


### PR DESCRIPTION
I assume it's OK to just "update" 0.2.4, because it hasn't really been released?