### PR TITLE
Bug 1491867: Release fluent-pseudo 0.3.1 with the updated README

### DIFF
--- a/fluent-pseudo/CHANGELOG.md
+++ b/fluent-pseudo/CHANGELOG.md
@@ -4,8 +4,11 @@
 
   - …
 
+## fluent-pseudo 0.3.1 (July 21, 2021)
+  - Update README to document the API changes in 0.3.0.
+
 ## fluent-pseudo 0.3.0 (July 19, 2021)
-  - Ability to wrap strings in markers.
+  - Breaking change: Add ability to wrap strings in markers.
 
 ## fluent-pseudo 0.2.3 (November 12, 2020)
   - Improve readability of the accented pseudo.

--- a/fluent-pseudo/Cargo.toml
+++ b/fluent-pseudo/Cargo.toml
@@ -3,7 +3,7 @@ name = "fluent-pseudo"
 description = """
 Pseudolocalization transformation API for use with Project Fluent API.
 """
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = [
     "Zibi Braniecki <gandalf@mozilla.com>",

--- a/fluent-pseudo/README.md
+++ b/fluent-pseudo/README.md
@@ -18,7 +18,7 @@ use fluent_pseudo::transform;
 
 fn transform_wrapper(s: &str) -> Cow<str> {
     // Not flipped and elongated pseudolocalization.
-    transform(s, false, true)
+    transform(s, false, true, false)
 }
 
 


### PR DESCRIPTION
Updating the README file to reflect API changes in 0.3.0.

![](https://media.giphy.com/media/bAftZ12SC0uEjLndIh/giphy.gif)