### PR TITLE
Allow optional resources

### DIFF
--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 High-level abstraction model for managing localization resources
 and runtime localization lifecycle.
 """
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 authors = [
     "Zibi Braniecki <gandalf@mozilla.com>",
@@ -19,7 +19,7 @@ categories = ["localization", "internationalization"]
 
 [dependencies]
 chunky-vec = "0.1"
-fluent-bundle = "0.15.1"
+fluent-bundle = { path = "../fluent-bundle" }
 futures = "0.3"
 async-trait = "0.1"
 unic-langid = { version = "0.9" }

--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 High-level abstraction model for managing localization resources
 and runtime localization lifecycle.
 """
-version = "0.5.1"
+version = "0.6.0"
 edition = "2018"
 authors = [
     "Zibi Braniecki <gandalf@mozilla.com>",

--- a/fluent-fallback/examples/simple-fallback.rs
+++ b/fluent-fallback/examples/simple-fallback.rs
@@ -23,6 +23,7 @@ use std::{env, fs, io, path::PathBuf, str::FromStr};
 use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
 use fluent_fallback::{
     generator::{BundleGenerator, FluentBundleResult},
+    types::ResourceId,
     Localization,
 };
 use fluent_langneg::{negotiate_languages, NegotiationStrategy};
@@ -167,7 +168,7 @@ fn collatz(n: isize) -> isize {
 struct BundleIter {
     res_path_scheme: String,
     locales: <Vec<LanguageIdentifier> as IntoIterator>::IntoIter,
-    res_ids: Vec<String>,
+    res_ids: Vec<ResourceId>,
 }
 
 impl Iterator for BundleIter {
@@ -184,7 +185,7 @@ impl Iterator for BundleIter {
         let mut errors = vec![];
 
         for res_id in &self.res_ids {
-            let res_path = res_path_scheme.as_str().replace("{res_id}", res_id);
+            let res_path = res_path_scheme.as_str().replace("{res_id}", &res_id.value);
             let source = fs::read_to_string(res_path).unwrap();
             let res = match FluentResource::try_new(source) {
                 Ok(res) => res,
@@ -221,7 +222,11 @@ impl BundleGenerator for Bundles {
     type Iter = BundleIter;
     type Stream = BundleIter;
 
-    fn bundles_iter(&self, locales: Self::LocalesIter, res_ids: Vec<String>) -> Self::Iter {
+    fn bundles_iter(
+        &self,
+        locales: std::vec::IntoIter<LanguageIdentifier>,
+        res_ids: Vec<ResourceId>,
+    ) -> Self::Iter {
         BundleIter {
             res_path_scheme: self.res_path_scheme.to_string_lossy().to_string(),
             locales,

--- a/fluent-fallback/src/bundles.rs
+++ b/fluent-fallback/src/bundles.rs
@@ -3,7 +3,7 @@ use crate::{
     env::LocalesProvider,
     errors::LocalizationError,
     generator::{BundleGenerator, BundleIterator, BundleStream},
-    types::{L10nAttribute, L10nKey, L10nMessage},
+    types::{L10nAttribute, L10nKey, L10nMessage, ResourceId},
 };
 use fluent_bundle::{FluentArgs, FluentBundle, FluentError};
 use std::borrow::Cow;
@@ -50,7 +50,7 @@ impl<G> Bundles<G>
 where
     G: BundleGenerator,
 {
-    pub fn new<P>(sync: bool, res_ids: Vec<String>, generator: &G, provider: &P) -> Self
+    pub fn new<P>(sync: bool, res_ids: Vec<ResourceId>, generator: &G, provider: &P) -> Self
     where
         G: BundleGenerator<LocalesIter = P::Iter>,
         P: LocalesProvider,

--- a/fluent-fallback/src/generator.rs
+++ b/fluent-fallback/src/generator.rs
@@ -3,6 +3,8 @@ use futures::Stream;
 use std::borrow::Borrow;
 use unic_langid::LanguageIdentifier;
 
+use crate::types::ResourceId;
+
 pub type FluentBundleResult<R> = Result<FluentBundle<R>, (FluentBundle<R>, Vec<FluentError>)>;
 
 pub trait BundleIterator {
@@ -20,11 +22,15 @@ pub trait BundleGenerator {
     type Iter: Iterator<Item = FluentBundleResult<Self::Resource>>;
     type Stream: Stream<Item = FluentBundleResult<Self::Resource>>;
 
-    fn bundles_iter(&self, _locales: Self::LocalesIter, _res_ids: Vec<String>) -> Self::Iter {
+    fn bundles_iter(&self, _locales: Self::LocalesIter, _res_ids: Vec<ResourceId>) -> Self::Iter {
         unimplemented!();
     }
 
-    fn bundles_stream(&self, _locales: Self::LocalesIter, _res_ids: Vec<String>) -> Self::Stream {
+    fn bundles_stream(
+        &self,
+        _locales: Self::LocalesIter,
+        _res_ids: Vec<ResourceId>,
+    ) -> Self::Stream {
         unimplemented!();
     }
 }

--- a/fluent-fallback/src/lib.rs
+++ b/fluent-fallback/src/lib.rs
@@ -32,8 +32,8 @@
 //!
 //! let loc = Localization::with_env(
 //!     vec![
-//!         "test.ftl".to_string(),
-//!         "test2.ftl".to_string()
+//!         "test.ftl".into(),
+//!         "test2.ftl".into()
 //!     ],
 //!     true,
 //!     vec![langid!("en-US")],

--- a/fluent-fallback/src/lib.rs
+++ b/fluent-fallback/src/lib.rs
@@ -24,7 +24,7 @@
 //! # Example
 //!
 //! ```
-//! use fluent_fallback::Localization;
+//! use fluent_fallback::{Localization, types::{ResourceType, ToResourceId}};
 //! use fluent_resmgr::ResourceManager;
 //! use unic_langid::langid;
 //!
@@ -33,7 +33,7 @@
 //! let loc = Localization::with_env(
 //!     vec![
 //!         "test.ftl".into(),
-//!         "test2.ftl".into()
+//!         "test2.ftl".to_resource_id(ResourceType::Optional),
 //!     ],
 //!     true,
 //!     vec![langid!("en-US")],
@@ -58,6 +58,20 @@
 //! In particular, modern software may have needs for both synchronous
 //! and asynchronous I/O. That, in turn has a large impact on what can happen
 //! in case of missing resources, or errors.
+//!
+//! Resource identifiers can refer to resources that are either required or optional.
+//! In the above example, `"test.ftl"` is a required resource (the default using `.into()`),
+//! and `"test2.ftl" is an optional resource, which you can create via the
+//! [`ToResourceId`](fluent_fallback::types::ToResourceId) trait.
+//!
+//! A required resource must be present in order for the a bundle to be considered valid.
+//! If a required resource is missing for a given locale, a bundle will not be generated for that locale.
+//!
+//! A bundle is still considered valid if an optional resource is missing. A bundle will still be generated
+//! and the entries for the missing optional resource will simply be missing from the bundle. This should be
+//! used sparingly in exceptional cases where you do not want `Localization` to fall back to the next
+//! locale if there is a missing resource. Marking all resources as optional will increase the state space
+//! that the solver has to search through, and will have a negative impact on performance.
 //!
 //! Currently, [`Localization`] can be specialized over an implementation of
 //! [`generator::BundleGenerator`] trait which provides a method to generate an

--- a/fluent-fallback/src/localization.rs
+++ b/fluent-fallback/src/localization.rs
@@ -2,6 +2,7 @@ use crate::{
     bundles::Bundles,
     env::LocalesProvider,
     generator::{BundleGenerator, BundleIterator, BundleStream},
+    types::ResourceId,
 };
 use once_cell::sync::OnceCell;
 use std::rc::Rc;
@@ -15,7 +16,7 @@ where
     generator: G,
     provider: P,
     sync: bool,
-    res_ids: Vec<String>,
+    res_ids: Vec<ResourceId>,
 }
 
 impl<G, P> Localization<G, P>
@@ -23,7 +24,7 @@ where
     G: BundleGenerator<LocalesIter = P::Iter> + Default,
     P: LocalesProvider + Default,
 {
-    pub fn new(res_ids: Vec<String>, sync: bool) -> Self {
+    pub fn new(res_ids: Vec<ResourceId>, sync: bool) -> Self {
         Self {
             bundles: OnceCell::new(),
             generator: G::default(),
@@ -39,7 +40,7 @@ where
     G: BundleGenerator<LocalesIter = P::Iter>,
     P: LocalesProvider,
 {
-    pub fn with_env(res_ids: Vec<String>, sync: bool, provider: P, generator: G) -> Self {
+    pub fn with_env(res_ids: Vec<ResourceId>, sync: bool, provider: P, generator: G) -> Self {
         Self {
             bundles: OnceCell::new(),
             generator,
@@ -53,23 +54,23 @@ where
         self.sync
     }
 
-    pub fn add_resource_id(&mut self, res_id: String) {
-        self.res_ids.push(res_id);
+    pub fn add_resource_id<T: Into<ResourceId>>(&mut self, res_id: T) {
+        self.res_ids.push(res_id.into());
         self.on_change();
     }
 
-    pub fn add_resource_ids(&mut self, res_ids: Vec<String>) {
+    pub fn add_resource_ids(&mut self, res_ids: Vec<ResourceId>) {
         self.res_ids.extend(res_ids);
         self.on_change();
     }
 
-    pub fn remove_resource_id(&mut self, res_id: String) -> usize {
-        self.res_ids.retain(|x| *x != res_id);
+    pub fn remove_resource_id<T: PartialEq<ResourceId>>(&mut self, res_id: T) -> usize {
+        self.res_ids.retain(|x| !res_id.eq(x));
         self.on_change();
         self.res_ids.len()
     }
 
-    pub fn remove_resource_ids(&mut self, res_ids: Vec<String>) -> usize {
+    pub fn remove_resource_ids(&mut self, res_ids: Vec<ResourceId>) -> usize {
         self.res_ids.retain(|x| !res_ids.contains(x));
         self.on_change();
         self.res_ids.len()

--- a/fluent-fallback/src/types.rs
+++ b/fluent-fallback/src/types.rs
@@ -27,3 +27,111 @@ pub struct L10nMessage<'l> {
     pub value: Option<Cow<'l, str>>,
     pub attributes: Vec<L10nAttribute<'l>>,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceType {
+    /// This is a required resource.
+    ///
+    /// A bundle generator should not consider a solution as valid
+    /// if this resource is missing.
+    ///
+    /// This is the default when creating a [`ResourceId`].
+    Required,
+
+    /// This is an optional resource.
+    ///
+    /// A bundle generator should still populate a partial solution
+    /// even if this resource is missing.
+    ///
+    /// This is intended for experimental and/or under-development
+    /// resources that may not have content for all supported locales.
+    ///
+    /// This should be used sparingly, as it will greatly increase
+    /// the state space of the search for valid solutions which can
+    /// have a severe impact on performance.
+    Optional,
+}
+
+/// A resource identifier for a localization resource.
+#[derive(Debug, Clone)]
+pub struct ResourceId {
+    /// The resource identifier.
+    pub value: String,
+
+    /// The [`ResourceType`] for this resource.
+    ///
+    /// The default value (when converting from another type) is
+    /// [`ResourceType::Required`]. You should only set this to
+    /// [`ResourceType::Optional`] for experimental or under-development
+    /// features that may not yet have content in all eventually-supported locales.
+    ///
+    /// Setting this value to [`ResourceType::Optional`] for all resources
+    /// may have a severe impact on performance due to increasing the state space
+    /// of the solver.
+    pub resource_type: ResourceType,
+}
+
+impl ResourceId {
+    /// Returns [`true`] if the resource has [`ResourceType::Required`],
+    /// otherwise returns [`false`].
+    pub fn is_required(&self) -> bool {
+        matches!(self.resource_type, ResourceType::Required)
+    }
+
+    /// Returns [`true`] if the resource has [`ResourceType::Optional`],
+    /// otherwise returns [`false`].
+    pub fn is_optional(&self) -> bool {
+        matches!(self.resource_type, ResourceType::Optional)
+    }
+}
+
+impl<S: Into<String>> From<S> for ResourceId {
+    fn from(id: S) -> Self {
+        Self {
+            value: id.into(),
+            resource_type: ResourceType::Required,
+        }
+    }
+}
+
+impl std::fmt::Display for ResourceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl PartialEq<str> for ResourceId {
+    fn eq(&self, other: &str) -> bool {
+        self.value.as_str().eq(other)
+    }
+}
+
+impl Eq for ResourceId {}
+impl PartialEq for ResourceId {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+
+/// A trait for creating a [`ResourceId`] from another type.
+///
+/// This differs from the [`From`] trait in that the [`From`] trait
+/// always takes the default resource type of [`ResourceType::Required`].
+///
+/// If you need to create a resource with a non-default [`ResourceType`],
+/// such as [`ResourceType::Optional`], then use this trait.
+///
+/// This trait is automatically implemented for types that implement [`Into<String>`].
+pub trait ToResourceId {
+    /// Creates a [`ResourceId`] from [`self`], given a [`ResourceType`].
+    fn to_resource_id(self, resource_type: ResourceType) -> ResourceId;
+}
+
+impl<S: Into<String>> ToResourceId for S {
+    fn to_resource_id(self, fallback_strategy: ResourceType) -> ResourceId {
+        ResourceId {
+            value: self.into(),
+            resource_type: fallback_strategy,
+        }
+    }
+}

--- a/fluent-fallback/src/types.rs
+++ b/fluent-fallback/src/types.rs
@@ -72,6 +72,13 @@ pub struct ResourceId {
 }
 
 impl ResourceId {
+    pub fn new<S: Into<String>>(value: S, resource_type: ResourceType) -> Self {
+        Self {
+            value: value.into(),
+            resource_type,
+        }
+    }
+
     /// Returns [`true`] if the resource has [`ResourceType::Required`],
     /// otherwise returns [`false`].
     pub fn is_required(&self) -> bool {
@@ -128,10 +135,7 @@ pub trait ToResourceId {
 }
 
 impl<S: Into<String>> ToResourceId for S {
-    fn to_resource_id(self, fallback_strategy: ResourceType) -> ResourceId {
-        ResourceId {
-            value: self.into(),
-            resource_type: fallback_strategy,
-        }
+    fn to_resource_id(self, resource_type: ResourceType) -> ResourceId {
+        ResourceId::new(self.into(), resource_type)
     }
 }

--- a/fluent-fallback/tests/localization_test.rs
+++ b/fluent-fallback/tests/localization_test.rs
@@ -8,7 +8,7 @@ use fluent_bundle::{
 use fluent_fallback::{
     env::LocalesProvider,
     generator::{BundleGenerator, FluentBundleResult},
-    types::L10nKey,
+    types::{L10nKey, ResourceId},
     Localization, LocalizationError,
 };
 use std::cell::RefCell;
@@ -55,7 +55,7 @@ impl LocalesProvider for Locales {
 // lack of GATs, these have to own members instead of taking slices.
 struct BundleIter {
     locales: <Vec<LanguageIdentifier> as IntoIterator>::IntoIter,
-    res_ids: Vec<String>,
+    res_ids: Vec<ResourceId>,
 }
 
 impl Iterator for BundleIter {
@@ -102,7 +102,7 @@ impl futures::Stream for BundleIter {
 
             let mut errors = vec![];
             for res_id in &self.res_ids {
-                let full_path = format!("./tests/resources/{}/{}", locale, res_id);
+                let full_path = format!("./tests/resources/{}/{}", locale, res_id.value);
                 let source = fs::read_to_string(full_path).unwrap();
                 let res = match FluentResource::try_new(source) {
                     Ok(res) => res,
@@ -132,18 +132,18 @@ impl BundleGenerator for ResourceManager {
     type Iter = BundleIter;
     type Stream = BundleIter;
 
-    fn bundles_iter(&self, locales: Self::LocalesIter, res_ids: Vec<String>) -> Self::Iter {
+    fn bundles_iter(&self, locales: Self::LocalesIter, res_ids: Vec<ResourceId>) -> Self::Iter {
         BundleIter { locales, res_ids }
     }
 
-    fn bundles_stream(&self, locales: Self::LocalesIter, res_ids: Vec<String>) -> Self::Stream {
+    fn bundles_stream(&self, locales: Self::LocalesIter, res_ids: Vec<ResourceId>) -> Self::Stream {
         BundleIter { locales, res_ids }
     }
 }
 
 #[test]
 fn localization_format() {
-    let resource_ids: Vec<String> = vec!["test.ftl".into(), "test2.ftl".into()];
+    let resource_ids: Vec<ResourceId> = vec!["test.ftl".into(), "test2.ftl".into()];
     let locales = Locales::new(vec![langid!("pl"), langid!("en-US")]);
     let res_mgr = ResourceManager;
     let mut errors = vec![];
@@ -171,7 +171,7 @@ fn localization_format() {
 
 #[test]
 fn localization_on_change() {
-    let resource_ids: Vec<String> = vec!["test.ftl".into(), "test2.ftl".into()];
+    let resource_ids: Vec<ResourceId> = vec!["test.ftl".into(), "test2.ftl".into()];
 
     let mut locales = Locales::new(vec![langid!("en-US")]);
     let res_mgr = ResourceManager;
@@ -197,7 +197,7 @@ fn localization_on_change() {
 
 #[test]
 fn localization_format_value_missing_errors() {
-    let resource_ids: Vec<String> = vec!["test.ftl".into(), "test2.ftl".into()];
+    let resource_ids: Vec<ResourceId> = vec!["test.ftl".into(), "test2.ftl".into()];
 
     let locales = Locales::new(vec![langid!("pl"), langid!("en-US")]);
     let res_mgr = ResourceManager;
@@ -253,7 +253,7 @@ fn localization_format_value_missing_errors() {
 
 #[test]
 fn localization_format_value_sync_missing_errors() {
-    let resource_ids: Vec<String> = vec!["test.ftl".into(), "test2.ftl".into()];
+    let resource_ids: Vec<ResourceId> = vec!["test.ftl".into(), "test2.ftl".into()];
 
     let locales = Locales::new(vec![langid!("pl"), langid!("en-US")]);
     let res_mgr = ResourceManager;
@@ -309,7 +309,7 @@ fn localization_format_value_sync_missing_errors() {
 
 #[test]
 fn localization_format_values_sync_missing_errors() {
-    let resource_ids: Vec<String> = vec!["test.ftl".into(), "test2.ftl".into()];
+    let resource_ids: Vec<ResourceId> = vec!["test.ftl".into(), "test2.ftl".into()];
 
     let locales = Locales::new(vec![langid!("pl"), langid!("en-US")]);
     let res_mgr = ResourceManager;
@@ -380,7 +380,7 @@ fn localization_format_values_sync_missing_errors() {
 
 #[test]
 fn localization_format_messages_sync_missing_errors() {
-    let resource_ids: Vec<String> = vec!["test.ftl".into(), "test2.ftl".into()];
+    let resource_ids: Vec<ResourceId> = vec!["test.ftl".into(), "test2.ftl".into()];
 
     let locales = Locales::new(vec![langid!("pl"), langid!("en-US")]);
     let res_mgr = ResourceManager;
@@ -428,7 +428,7 @@ fn localization_format_messages_sync_missing_errors() {
 
 #[test]
 fn localization_format_missing_argument_error() {
-    let resource_ids: Vec<String> = vec!["test2.ftl".into()];
+    let resource_ids: Vec<ResourceId> = vec!["test2.ftl".into()];
     let locales = Locales::new(vec![langid!("en-US")]);
     let res_mgr = ResourceManager;
     let mut errors = vec![];
@@ -475,7 +475,7 @@ fn localization_format_missing_argument_error() {
 
 #[tokio::test]
 async fn localization_handle_state_changes_mid_async() {
-    let resource_ids: Vec<String> = vec!["test.ftl".into()];
+    let resource_ids: Vec<ResourceId> = vec!["test.ftl".into()];
     let locales = Locales::new(vec![langid!("en-US")]);
     let res_mgr = ResourceManager;
     let mut errors = vec![];

--- a/fluent-pseudo/src/lib.rs
+++ b/fluent-pseudo/src/lib.rs
@@ -58,7 +58,7 @@ pub fn transform_dom(s: &str, flipped: bool, elongate: bool, with_markers: bool)
     result.to_mut().replace_range(result_range, &transform_sub);
 
     if with_markers {
-        return Cow::from("[") + result + "]"
+        return Cow::from("[") + result + "]";
     }
 
     result

--- a/fluent-pseudo/src/lib.rs
+++ b/fluent-pseudo/src/lib.rs
@@ -58,7 +58,7 @@ pub fn transform_dom(s: &str, flipped: bool, elongate: bool, with_markers: bool)
     result.to_mut().replace_range(result_range, &transform_sub);
 
     if with_markers {
-        return Cow::from("[") + result + "]";
+        return Cow::from("[") + result + "]"
     }
 
     result

--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -3,7 +3,7 @@ name = "fluent-resmgr"
 description = """
 Resource manager for Fluent localization resources.
 """
-version = "0.0.4"
+version = "0.0.5"
 authors = [
     "Zibi Braniecki <gandalf@mozilla.com>",
     "Staś Małolepszy <stas@mozilla.com>"
@@ -17,9 +17,9 @@ keywords = ["localization", "l10n", "i18n", "intl", "internationalization"]
 categories = ["localization", "internationalization"]
 
 [dependencies]
-fluent-bundle = "0.15"
+fluent-bundle = { path = "../fluent-bundle" }
+fluent-fallback = { path = "../fluent-fallback" }
 unic-langid = "0.9"
-fluent-fallback = { version = "0.5", path = "../fluent-fallback" }
 elsa = "1.3.2"
 futures = "0.3"
 

--- a/fluent-resmgr/src/resource_manager.rs
+++ b/fluent-resmgr/src/resource_manager.rs
@@ -1,6 +1,9 @@
 use elsa::FrozenMap;
 use fluent_bundle::{FluentBundle, FluentResource};
-use fluent_fallback::generator::{BundleGenerator, FluentBundleResult};
+use fluent_fallback::{
+    generator::{BundleGenerator, FluentBundleResult},
+    types::ResourceId,
+};
 use futures::stream::Stream;
 use std::fs;
 use std::io;
@@ -80,7 +83,7 @@ impl ResourceManager {
 // lack of GATs, these have to own members instead of taking slices.
 pub struct BundleIter {
     locales: <Vec<LanguageIdentifier> as IntoIterator>::IntoIter,
-    res_ids: Vec<String>,
+    res_ids: Vec<ResourceId>,
 }
 
 impl Iterator for BundleIter {
@@ -118,11 +121,15 @@ impl BundleGenerator for ResourceManager {
     type Iter = BundleIter;
     type Stream = BundleIter;
 
-    fn bundles_iter(&self, locales: Self::LocalesIter, res_ids: Vec<String>) -> Self::Iter {
+    fn bundles_iter(&self, locales: Self::LocalesIter, res_ids: Vec<ResourceId>) -> Self::Iter {
         BundleIter { locales, res_ids }
     }
 
-    fn bundles_stream(&self, _locales: Self::LocalesIter, _res_ids: Vec<String>) -> Self::Stream {
+    fn bundles_stream(
+        &self,
+        _locales: Self::LocalesIter,
+        _res_ids: Vec<ResourceId>,
+    ) -> Self::Stream {
         todo!()
     }
 }

--- a/fluent-testing/Cargo.toml
+++ b/fluent-testing/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "fluent-testing"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Zibi Braniecki <zibi@braniecki.net>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+fluent-bundle = { path = "../fluent-bundle" }
+fluent-fallback = { path = "../fluent-fallback" }
 tokio = { version = "1.0", optional = true, features = ["fs", "rt-multi-thread", "macros", "io-util"] }
 
 [features]

--- a/fluent-testing/Cargo.toml
+++ b/fluent-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluent-testing"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Zibi Braniecki <zibi@braniecki.net>"]
 edition = "2018"
 

--- a/fluent-testing/resources/empty-resource/pl/empty/empty-one.ftl
+++ b/fluent-testing/resources/empty-resource/pl/empty/empty-one.ftl
@@ -1,0 +1,1 @@
+empty-one = pusty

--- a/fluent-testing/resources/missing-resource/pl/missing/missing-one.ftl
+++ b/fluent-testing/resources/missing-resource/pl/missing/missing-one.ftl
@@ -1,0 +1,1 @@
+missing-one = zaginiony

--- a/fluent-testing/src/scenarios/empty_resource_all_locales.rs
+++ b/fluent-testing/src/scenarios/empty_resource_all_locales.rs
@@ -1,0 +1,25 @@
+use super::structs::*;
+use crate::queries;
+
+/// Tests bundle generation with a queried value that is missing in all resources
+/// in all locales. Despite the fact that the value is missing, this should have no
+/// effect on the ability to generate a bundle and look up other present values.
+pub fn get_scenario() -> Scenario {
+    Scenario::new(
+        "empty",
+        vec![
+            FileSource::new("browser", "browser/{locale}/", vec!["en-US", "pl"]),
+            FileSource::new("empty", "empty-resource/{locale}/", vec!["en-US", "pl"]),
+        ],
+        vec!["en-US", "pl"],
+        vec!["browser/sanitize.ftl", "empty/empty-all.ftl"],
+        queries![
+            ("history-section-label", "History", ExceptionalContext::None),
+            (
+                "empty-all",
+                "empty-all",
+                ExceptionalContext::ValueMissingFromAllResources,
+            )
+        ],
+    )
+}

--- a/fluent-testing/src/scenarios/empty_resource_one_locale.rs
+++ b/fluent-testing/src/scenarios/empty_resource_one_locale.rs
@@ -1,0 +1,25 @@
+use super::structs::*;
+use crate::queries;
+
+/// Tests bundle generation with a queried value that is missing in only one resource
+/// in the primary locale. This should cause the bundle to fallback to another locale
+/// only for that value.
+pub fn get_scenario() -> Scenario {
+    Scenario::new(
+        "empty",
+        vec![
+            FileSource::new("browser", "browser/{locale}/", vec!["en-US", "pl"]),
+            FileSource::new("empty", "empty-resource/{locale}/", vec!["en-US", "pl"]),
+        ],
+        vec!["en-US", "pl"],
+        vec!["browser/sanitize.ftl", "empty/empty-one.ftl"],
+        queries![
+            ("history-section-label", "History", ExceptionalContext::None),
+            (
+                "empty-one",
+                "pusty",
+                ExceptionalContext::ValueMissingFromResource,
+            )
+        ],
+    )
+}

--- a/fluent-testing/src/scenarios/missing_optional_all_locales.rs
+++ b/fluent-testing/src/scenarios/missing_optional_all_locales.rs
@@ -1,0 +1,36 @@
+use fluent_fallback::types::{ResourceType, ToResourceId};
+
+use super::structs::*;
+use crate::queries;
+
+/// Tests bundle generation with an optional resource that is missing from all locales.
+/// Since the resource is optional, we should still be able to generate a bundle and
+/// look up other present values, but we will fail to look up a value from the missing resource.
+pub fn get_scenario() -> Scenario {
+    Scenario::new(
+        "missing_optional_all_locales",
+        vec![
+            FileSource::new("browser", "browser/{locale}/", vec!["en-US", "pl"]),
+            FileSource::new("missing", "missing-resource/{locale}/", vec!["en-US", "pl"]),
+        ],
+        vec!["en-US", "pl"],
+        vec![
+            "browser/sanitize.ftl".into(),
+            "missing/missing-one.ftl".to_resource_id(ResourceType::Optional),
+            "missing/missing-all.ftl".to_resource_id(ResourceType::Optional),
+        ],
+        queries![
+            ("history-section-label", "History", ExceptionalContext::None),
+            (
+                "missing-one",
+                "zaginiony",
+                ExceptionalContext::OptionalResourceMissingFromLocale,
+            ),
+            (
+                "missing-all",
+                "missing-all",
+                ExceptionalContext::OptionalResourceMissingFromAllLocales,
+            )
+        ],
+    )
+}

--- a/fluent-testing/src/scenarios/missing_optional_one_locale.rs
+++ b/fluent-testing/src/scenarios/missing_optional_one_locale.rs
@@ -1,0 +1,30 @@
+use fluent_fallback::types::{ResourceType, ToResourceId};
+
+use super::structs::*;
+use crate::queries;
+
+/// Tests bundle generation with an optional resource that is missing from only the primary locale.
+/// Since the resource is optional, we should only fallback to another locale for values in the missing
+/// optional resource. We should still be able to use the primary locale for other present values/resources.
+pub fn get_scenario() -> Scenario {
+    Scenario::new(
+        "missing_optional_one_locale",
+        vec![
+            FileSource::new("browser", "browser/{locale}/", vec!["en-US", "pl"]),
+            FileSource::new("missing", "missing-resource/{locale}/", vec!["en-US", "pl"]),
+        ],
+        vec!["en-US", "pl"],
+        vec![
+            "browser/sanitize.ftl".into(),
+            "missing/missing-one.ftl".to_resource_id(ResourceType::Optional),
+        ],
+        queries![
+            ("history-section-label", "History", ExceptionalContext::None),
+            (
+                "missing-one",
+                "zaginiony",
+                ExceptionalContext::OptionalResourceMissingFromLocale,
+            )
+        ],
+    )
+}

--- a/fluent-testing/src/scenarios/missing_required_all_locales.rs
+++ b/fluent-testing/src/scenarios/missing_required_all_locales.rs
@@ -1,0 +1,38 @@
+use super::structs::*;
+use crate::queries;
+
+/// Tests bundle generation with a required resource that is missing from all locales.
+/// Since the resource is required, we cannot generate a bundle because no solution exists.
+/// Lookups for all values should fail, because no bundle will be generated.
+pub fn get_scenario() -> Scenario {
+    Scenario::new(
+        "missing_required_all_locales",
+        vec![
+            FileSource::new("browser", "browser/{locale}/", vec!["en-US", "pl"]),
+            FileSource::new("missing", "missing-resource/{locale}/", vec!["en-US", "pl"]),
+        ],
+        vec!["en-US", "pl"],
+        vec![
+            "browser/sanitize.ftl",
+            "missing/missing-one.ftl",
+            "missing/missing-all.ftl",
+        ],
+        queries![
+            (
+                "history-section-label",
+                "history-section-label",
+                ExceptionalContext::None,
+            ),
+            (
+                "missing-one",
+                "missing-one",
+                ExceptionalContext::RequiredResourceMissingFromLocale,
+            ),
+            (
+                "missing-all",
+                "missing-all",
+                ExceptionalContext::RequiredResourceMissingFromAllLocales,
+            )
+        ],
+    )
+}

--- a/fluent-testing/src/scenarios/missing_required_one_locale.rs
+++ b/fluent-testing/src/scenarios/missing_required_one_locale.rs
@@ -1,0 +1,28 @@
+use super::structs::*;
+use crate::queries;
+
+/// Tests bundle generation with a required resource that is missing from only the primary locale.
+/// Since the resource is required, we should only fallback entirely to the next locale for all resources.
+pub fn get_scenario() -> Scenario {
+    Scenario::new(
+        "missing_required_one_locale",
+        vec![
+            FileSource::new("browser", "browser/{locale}/", vec!["en-US", "pl"]),
+            FileSource::new("missing", "missing-resource/{locale}/", vec!["en-US", "pl"]),
+        ],
+        vec!["en-US", "pl"],
+        vec!["browser/sanitize.ftl", "missing/missing-one.ftl"],
+        queries![
+            (
+                "history-section-label",
+                "Historia",
+                ExceptionalContext::None
+            ),
+            (
+                "missing-one",
+                "zaginiony",
+                ExceptionalContext::RequiredResourceMissingFromLocale,
+            )
+        ],
+    )
+}

--- a/fluent-testing/src/scenarios/mod.rs
+++ b/fluent-testing/src/scenarios/mod.rs
@@ -1,4 +1,10 @@
 mod browser;
+mod empty_resource_all_locales;
+mod empty_resource_one_locale;
+mod missing_optional_all_locales;
+mod missing_optional_one_locale;
+mod missing_required_all_locales;
+mod missing_required_one_locale;
 mod preferences;
 mod simple;
 pub mod structs;
@@ -21,7 +27,13 @@ macro_rules! queries {
 pub fn get_scenarios() -> Vec<Scenario> {
     vec![
         simple::get_scenario(),
-        preferences::get_scenario(),
         browser::get_scenario(),
+        preferences::get_scenario(),
+        empty_resource_one_locale::get_scenario(),
+        empty_resource_all_locales::get_scenario(),
+        missing_optional_one_locale::get_scenario(),
+        missing_optional_all_locales::get_scenario(),
+        missing_required_one_locale::get_scenario(),
+        missing_required_all_locales::get_scenario(),
     ]
 }


### PR DESCRIPTION
- Add a new struct `ResourceId`.
    - `ResourceID`s can be optional or required.
- Update all code to use `ResourceId` instead of `String`.
- Add test scenario for empty resource in one locale.
- Add test scenario for empty resource in all locales.
- Add test scenario for missing optional resource in one locale.
- Add test scenario for missing optional resource in all locales.
- Add test scenario for missing required resource in one locale.
- Add test scenario for missing required resource in all locales.