### PR TITLE
Update versions for publishing

### DIFF
--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["localization", "internationalization"]
 
 [dependencies]
 chunky-vec = "0.1"
-fluent-bundle = { path = "../fluent-bundle" }
+fluent-bundle = { version = "0.15.2", path = "../fluent-bundle" }
 futures = "0.3"
 async-trait = "0.1"
 unic-langid = { version = "0.9" }
@@ -28,5 +28,5 @@ once_cell = "1.8"
 [dev-dependencies]
 fluent-langneg = "0.13"
 unic-langid = { version = "0.9", features = ["macros"] }
-fluent-resmgr = { path = "../fluent-resmgr" }
+fluent-resmgr = { version = "0.0.5", path = "../fluent-resmgr" }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }

--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -17,8 +17,8 @@ keywords = ["localization", "l10n", "i18n", "intl", "internationalization"]
 categories = ["localization", "internationalization"]
 
 [dependencies]
-fluent-bundle = { path = "../fluent-bundle" }
-fluent-fallback = { path = "../fluent-fallback" }
+fluent-bundle = { version = "0.15.2", path = "../fluent-bundle" }
+fluent-fallback = { version = "0.6.0", path = "../fluent-fallback" }
 unic-langid = "0.9"
 elsa = "1.3.2"
 futures = "0.3"

--- a/fluent-testing/Cargo.toml
+++ b/fluent-testing/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fluent-bundle = { path = "../fluent-bundle" }
-fluent-fallback = { path = "../fluent-fallback" }
+fluent-bundle = { version = "0.15.2", path = "../fluent-bundle" }
+fluent-fallback = { version = "0.6.0", path = "../fluent-fallback" }
 tokio = { version = "1.0", optional = true, features = ["fs", "rt-multi-thread", "macros", "io-util"] }
 
 [features]


### PR DESCRIPTION
I did not realize when merging #243 that even dependencies that point to local paths need an explicit version number.

I cannot run `cargo publish` unless the versions are explicit. 

This PR fixes those up for publishing. 