### PR TITLE
Update CHANGELOG files

### DIFF
--- a/fluent-fallback/CHANGELOG.md
+++ b/fluent-fallback/CHANGELOG.md
@@ -4,6 +4,9 @@
 
   - …
 
+## fluent-fallback 0.6.0 (Dec 17, 2021)
+  - Add `ResourceId` struct which allows fluent resources to be optional.
+
 ## fluent-fallback 0.5.0 (Jul 8, 2021)
   - Separate out `Bundles` for state management.
 

--- a/fluent-resmgr/CHANGELOG.md
+++ b/fluent-resmgr/CHANGELOG.md
@@ -4,6 +4,9 @@
 
   - …
 
+## fluent-resmgr 0.0.5 (Dec 17, 2021)
+  - Update `fluent-fallback` to 0.6.0.
+
 ## fluent-resmgr 0.0.4 (May 6, 2020)
   - Update `fluent-bundle` to 0.12.
   - Update `unic-langid` to 0.9.

--- a/fluent-testing/CHANGELOG.md
+++ b/fluent-testing/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+  - …
+
+## fluent-resmgr 0.0.2 (Dec 17, 2021)
+  - Ensure all test scenarios have unique names.
+
+## fluent-resmgr 0.0.1 (Dec 17, 2021)
+
+  - This is the first release to be listed in the CHANGELOG.
+  - Release fluent-testing as a crate.


### PR DESCRIPTION
Updates the CHANGELOG.md files for fluent-fallback and fluent-resmgr, which published new versions.

Adds a CHANGELONG.md file for fluent-testing, which is now available on crates.io.