### PR TITLE
Implement From<&String> for FluentValue

### DIFF
--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -189,6 +189,12 @@ impl<'source> From<String> for FluentValue<'source> {
     }
 }
 
+impl<'source> From<&'source String> for FluentValue<'source> {
+    fn from(s: &'source String) -> Self {
+        FluentValue::String(s.into())
+    }
+}
+
 impl<'source> From<&'source str> for FluentValue<'source> {
     fn from(s: &'source str) -> Self {
         FluentValue::String(s.into())


### PR DESCRIPTION
This is useful for macros such as i18-embed-fl's [`fl!`](https://docs.rs/i18n-embed-fl/0.6.4/i18n_embed_fl/macro.fl.html) to accept `String` values by reference without requiring `as_str` or slice syntax. It directly corresponds to [`impl<'a> From<&'a String> for Cow<'a, str>`](https://doc.rust-lang.org/1.59.0/std/borrow/enum.Cow.html#impl-From%3C%26%27a%20String%3E).