### PR TITLE
sync feature for ressource threading

### DIFF
--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -6,15 +6,15 @@ Resource manager for Fluent localization resources.
 version = "0.0.5"
 authors = [
     "Zibi Braniecki <gandalf@mozilla.com>",
-    "Staś Małolepszy <stas@mozilla.com>"
+    "Staś Małolepszy <stas@mozilla.com>",
 ]
 edition = "2021"
 homepage = "http://www.projectfluent.org"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/projectfluent/fluent-rs"
 readme = "README.md"
-keywords = ["localization", "l10n", "i18n", "intl", "internationalization"]
-categories = ["localization", "internationalization"]
+keywords = [ "localization", "l10n", "i18n", "intl", "internationalization" ]
+categories = [ "localization", "internationalization" ]
 
 [dependencies]
 fluent-bundle = { version = "0.15.2", path = "../fluent-bundle" }
@@ -24,5 +24,8 @@ elsa = "1.5"
 futures = "0.3"
 
 [dev-dependencies]
-unic-langid = { version = "0.9", features = ["macros"]}
+unic-langid = { version = "0.9", features = [ "macros" ] }
 fluent-langneg = "0.13"
+
+[features]
+sync = []

--- a/fluent-resmgr/src/resource_manager.rs
+++ b/fluent-resmgr/src/resource_manager.rs
@@ -1,4 +1,7 @@
-use elsa::FrozenMap;
+#[cfg(not(feature = "sync"))]
+use elsa::map::FrozenMap;
+#[cfg(feature = "sync")]
+use elsa::sync::FrozenMap;
 use fluent_bundle::{FluentBundle, FluentResource};
 use fluent_fallback::{
     generator::{BundleGenerator, FluentBundleResult},


### PR DESCRIPTION
Hi,
I think it could be interesting to allow using the [elsa::sync::FrozenMap](https://docs.rs/elsa/latest/elsa/sync/struct.FrozenMap.html) for ressource sharing between threads.

Let me known what you think.