### PR TITLE
docs: An attempt to fix broken links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Resource Manager for localization resources.
 ## fluent-cli
 
 Collection of command line tools for Fluent.
+

--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -130,7 +130,9 @@ use crate::types::FluentValue;
 /// As you may have noticed, [`fluent_bundle::FluentBundle`](crate::FluentBundle) is a specialization of [`fluent_bundle::bundle::FluentBundle`](crate::bundle::FluentBundle)
 /// which works with an [`IntlLangMemoizer`] over [`RefCell`](std::cell::RefCell).
 /// In scenarios where the memoizer must work concurrently, there's an implementation of
-/// [`IntlLangMemoizer`](intl_memoizer::concurrent::IntlLangMemoizer) that uses [`Mutex`](std::sync::Mutex) and there's [`FluentBundle::new_concurrent`] which works with that.
+/// [`IntlLangMemoizer`][concurrent::IntlLangMemoizer] that uses [`Mutex`](std::sync::Mutex) and there's [`FluentBundle::new_concurrent`] which works with that.
+///
+/// [concurrent::IntlLangMemoizer]: https://docs.rs/intl-memoizer/latest/intl_memoizer/concurrent/struct.IntlLangMemoizer.html
 pub struct FluentBundle<R, M> {
     pub locales: Vec<LanguageIdentifier>,
     pub(crate) resources: Vec<R>,

--- a/fluent-bundle/src/lib.rs
+++ b/fluent-bundle/src/lib.rs
@@ -3,7 +3,7 @@
 //! `fluent-bundle` is a mid-level component of the [Fluent Localization
 //! System](https://www.projectfluent.org).
 //!
-//! The crate builds on top of the low level [`fluent-syntax`](../fluent-syntax) package, and provides
+//! The crate builds on top of the low level [`fluent-syntax`](https://crates.io/crates/fluent-syntax) package, and provides
 //! foundational types and structures required for executing localization at runtime.
 //!
 //! There are four core concepts to understand Fluent runtime:

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -61,10 +61,10 @@ impl<T: Any + PartialEq> AnyEq for T {
 
 /// The `FluentValue` enum represents values which can be formatted to a String.
 ///
-/// Those values are either passed as arguments to [`FluentBundle::format_pattern`][] or
+/// Those values are either passed as arguments to [`FluentBundle::format_pattern`] or
 /// produced by functions, or generated in the process of pattern resolution.
 ///
-/// [`FluentBundle::format_pattern`]: ../bundle/struct.FluentBundle.html#method.format_pattern
+/// [`FluentBundle::format_pattern`]: crate::bundle::FluentBundle::format_pattern
 #[derive(Debug)]
 pub enum FluentValue<'source> {
     String(Cow<'source, str>),

--- a/fluent/src/lib.rs
+++ b/fluent/src/lib.rs
@@ -70,14 +70,10 @@
 //! optimize results.
 //!
 //! At the moment it is expected that users will use
-//! the `fluent-bundle` crate directly, while the ecosystem
+//! the [`fluent-bundle`](fluent_bundle) crate directly, while the ecosystem
 //! matures and higher level APIs are being developed.
 //!
-//! [`FluentBundle`]: ./struct.FluentBundle.html
-//! [`FluentResource`]: ./struct.FluentResource.html
-//! [`FluentMessage`]: ./struct.FluentMessage.html
-//! [`FluentArgs`]: ./type.FluentArgs.html
-//! [`FluentValue`]: ./struct.FluentValue.html
+//! [`FluentBundle`]: bundle::FluentBundle
 
 pub use fluent_bundle::*;
 


### PR DESCRIPTION
Tries to fix #257 (fixes all but one).

There are still many links that I could not fix in the `fluent` crate, but they are not a problem in the `fluent-bundle` crate. I do not understand why these problems arise.

## Relevant readings on Rust docs:

- Last addition to rustdoc capacities: https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html
- Frontend/backend crates pattern: https://users.rust-lang.org/t/cross-crate-documentation-links-in-a-workspace/67588
- Help linking to an external crate (for which we want to link only on the documentation level): https://github.com/rust-lang/api-guidelines/discussions/186
- Open issue on how to do that: https://github.com/rust-lang/rust/issues/74481

## Useful tools

I can recommend trying [`cargo-deadlinks`](https://github.com/deadlinks/cargo-deadlinks). It helped find broken links, even if the error message is not the best.