### PR TITLE
Add options for cardinal/ordinal plural types

### DIFF
--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -131,13 +131,16 @@ impl<'source> FluentValue<'source> {
                     "other" => PluralCategory::OTHER,
                     _ => return false,
                 };
+                let kind = match b.options.kind {
+                    FluentNumberKind::Cardinal => PluralRuleType::CARDINAL,
+                    FluentNumberKind::Ordinal => PluralRuleType::ORDINAL,
+                };
                 scope
                     .bundle
                     .intls
-                    .with_try_get_threadsafe::<PluralRules, _, _>(
-                        (PluralRuleType::CARDINAL,),
-                        |pr| pr.0.select(b) == Ok(cat),
-                    )
+                    .with_try_get_threadsafe::<PluralRules, _, _>((kind,), |pr| {
+                        pr.0.select(b) == Ok(cat)
+                    })
                     .unwrap()
             }
             _ => false,

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -9,6 +9,28 @@ use crate::args::FluentArgs;
 use crate::types::FluentValue;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum FluentNumberKind {
+    Cardinal,
+    Ordinal,
+}
+
+impl std::default::Default for FluentNumberKind {
+    fn default() -> Self {
+        Self::Cardinal
+    }
+}
+
+impl From<&str> for FluentNumberKind {
+    fn from(input: &str) -> Self {
+        match input {
+            "cardinal" => Self::Cardinal,
+            "ordinal" => Self::Ordinal,
+            _ => Self::default(),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum FluentNumberStyle {
     Decimal,
     Currency,
@@ -58,6 +80,7 @@ impl From<&str> for FluentNumberCurrencyDisplayStyle {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct FluentNumberOptions {
+    pub kind: FluentNumberKind,
     pub style: FluentNumberStyle,
     pub currency: Option<String>,
     pub currency_display: FluentNumberCurrencyDisplayStyle,
@@ -72,6 +95,7 @@ pub struct FluentNumberOptions {
 impl Default for FluentNumberOptions {
     fn default() -> Self {
         Self {
+            kind: Default::default(),
             style: Default::default(),
             currency: None,
             currency_display: Default::default(),


### PR DESCRIPTION
Adds functionality for switching between plural types (cardinal and ordinal).

Fluent docs include this option in the `NUMBER` built-in function. Since `fluent-rs` doesn't have that yet, I included it in the place where all the other number options were. Please let me know if this isn't the appropriate place / way to include this functionality.

Also, I called it `kind` instead of `type` since the latter is a Rust keyword... a little weird but not sure if there's a better way to deal with that.