### PR TITLE
Resolve function instead in impl ResolveValue

### DIFF
--- a/fluent-bundle/src/resolver/inline_expression.rs
+++ b/fluent-bundle/src/resolver/inline_expression.rs
@@ -171,6 +171,19 @@ impl<'p> ResolveValue for ast::InlineExpression<&'p str> {
                     FluentValue::Error
                 }
             }
+            Self::FunctionReference { id, arguments } => {
+                let (resolved_positional_args, resolved_named_args) =
+                    scope.get_arguments(Some(arguments));
+
+                let func = scope.bundle.get_entry_function(id.name);
+
+                if let Some(func) = func {
+                    let result = func(resolved_positional_args.as_slice(), &resolved_named_args);
+                    result
+                } else {
+                    FluentValue::Error
+                }
+            }
             _ => {
                 let mut result = String::new();
                 self.write(&mut result, scope).expect("Failed to write");

--- a/fluent-bundle/tests/function.rs
+++ b/fluent-bundle/tests/function.rs
@@ -1,0 +1,104 @@
+use fluent_bundle::types::FluentNumber;
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
+
+#[test]
+fn test_function_resolve() {
+    // 1. Create bundle
+    let ftl_string = String::from(
+        "
+liked-count = { $num ->
+        [0]     No likes yet.
+        [one]   One person liked your message
+       *[other] { $num } people liked your message
+    }
+
+liked-count2 = { NUMBER($num) ->
+        [0]     No likes yet.
+        [one]   One person liked your message
+       *[other] { $num } people liked your message
+    }
+    ",
+    );
+
+    let res = FluentResource::try_new(ftl_string).expect("Could not parse an FTL string.");
+    let mut bundle = FluentBundle::default();
+
+    bundle
+        .add_function("NUMBER", |positional, named| match positional.get(0) {
+            Some(FluentValue::Number(n)) => {
+                let mut num = n.clone();
+                num.options.merge(named);
+
+                FluentValue::Number(num)
+            }
+            Some(FluentValue::String(s)) => {
+                let num: f64 = if let Ok(n) = s.to_owned().parse() {
+                    n
+                } else {
+                    return FluentValue::Error;
+                };
+                let mut num = FluentNumber {
+                    value: num,
+                    options: Default::default(),
+                };
+                num.options.merge(named);
+
+                FluentValue::Number(num)
+            }
+            _ => FluentValue::Error,
+        })
+        .expect("Failed to add a function.");
+
+    bundle
+        .add_resource(res)
+        .expect("Failed to add FTL resources to the bundle.");
+
+    // 2. Example without NUMBER call
+    let msg = bundle
+        .get_message("liked-count")
+        .expect("Message doesn't exist.");
+
+    let mut args = FluentArgs::new();
+    args.set("num", FluentValue::from("1"));
+
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    assert_eq!("\u{2068}1\u{2069} people liked your message", &value);
+
+    // 3. Example with passing number, but without NUMBER call
+    let mut args = FluentArgs::new();
+    args.set("num", FluentValue::from(1));
+
+    let msg = bundle
+        .get_message("liked-count")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    assert_eq!("One person liked your message", &value);
+
+    // 4. Example with NUMBER call
+    let mut args = FluentArgs::new();
+    args.set("num", FluentValue::from("1"));
+
+    let msg = bundle
+        .get_message("liked-count2")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    assert_eq!("One person liked your message", &value);
+
+    // 5. Example with NUMBER call from number
+    let mut args = FluentArgs::new();
+    args.set("num", FluentValue::from(1));
+
+    let msg = bundle
+        .get_message("liked-count2")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    assert_eq!("One person liked your message", &value);
+}


### PR DESCRIPTION
Before this change, we were using the version from WriteValue, which
basically ignored the type of function and always converted it to string,
which made NUMBER function useless when used on strings or even wrong
when used on numbers.
Fixes #261 