### PR TITLE
Make fluent_args macro work with trailing comma

### DIFF
--- a/fluent/src/lib.rs
+++ b/fluent/src/lib.rs
@@ -86,13 +86,13 @@ pub use fluent_bundle::*;
 ///
 /// let mut args = fluent_args![
 ///     "name" => "John",
-///     "emailCount" => 5
+///     "emailCount" => 5,
 /// ];
 ///
 /// ```
 #[macro_export]
 macro_rules! fluent_args {
-    ( $($key:expr => $value:expr),* ) => {
+    ( $($key:expr => $value:expr),* $(,)? ) => {
         {
             let mut args: $crate::FluentArgs = $crate::FluentArgs::new();
             $(

--- a/fluent/tests/macro.rs
+++ b/fluent/tests/macro.rs
@@ -7,7 +7,7 @@ fn test_fluent_args() {
     let args = fluent_args![
         "name" => "John",
         "emailCount" => 5,
-        "customValue" => FluentValue::from("My Value")
+        "customValue" => FluentValue::from("My Value"),
     ];
     assert_eq!(
         args.get("name"),


### PR DESCRIPTION
Fixes #266 