### PR TITLE
Inconsistent and misleading? behavior for FluentArgs::set

### DIFF
--- a/fluent-bundle/src/args.rs
+++ b/fluent-bundle/src/args.rs
@@ -123,14 +123,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn replace_existing_argument() {
+    fn replace_existing_arguments() {
         let mut args = FluentArgs::new();
-        args.set("variable", "first value");
-        args.set("variable", "second value");
-        assert_eq!(args.0.len(), 1);
+
+        args.set("name", "John");
+        args.set("emailCount", 5);
+        assert_eq!(args.0.len(), 2);
         assert_eq!(
-            args.get("variable").unwrap(),
-            &FluentValue::from("second value")
+            args.get("name"),
+            Some(&FluentValue::String(Cow::Borrowed("John")))
         );
+        assert_eq!(args.get("emailCount"), Some(&FluentValue::try_number(5)));
+
+        args.set("name", "Jane");
+        args.set("emailCount", 7);
+        assert_eq!(args.0.len(), 2);
+        assert_eq!(
+            args.get("name"),
+            Some(&FluentValue::String(Cow::Borrowed("Jane")))
+        );
+        assert_eq!(args.get("emailCount"), Some(&FluentValue::try_number(7)));
     }
 }

--- a/fluent-bundle/src/args.rs
+++ b/fluent-bundle/src/args.rs
@@ -74,11 +74,10 @@ impl<'args> FluentArgs<'args> {
         V: Into<FluentValue<'args>>,
     {
         let key = key.into();
-        let idx = match self.0.binary_search_by_key(&&key, |(k, _)| k) {
-            Ok(idx) => idx,
-            Err(idx) => idx,
+        match self.0.binary_search_by_key(&&key, |(k, _)| k) {
+            Ok(idx) => self.0[idx] = (key, value.into()),
+            Err(idx) => self.0.insert(idx, (key, value.into())),
         };
-        self.0.insert(idx, (key, value.into()));
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&str, &FluentValue)> {
@@ -116,5 +115,22 @@ impl<'args> IntoIterator for FluentArgs<'args> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replace_existing_argument() {
+        let mut args = FluentArgs::new();
+        args.set("variable", "first value");
+        args.set("variable", "second value");
+        assert_eq!(args.0.len(), 1);
+        assert_eq!(
+            args.get("variable").unwrap(),
+            &FluentValue::from("second value")
+        );
     }
 }


### PR DESCRIPTION
Hi,

There is an inconsistent result when we set an argument that already exists, but I think the main issue is that when we set an argument that already exists it doesn't replace the argument in the underlying `Vec` but it is added.

There is an example that show the issue and my proposition to fix that.

```rust
use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};

fn main() {
    let res = FluentResource::try_new(
        r#"
hello = Hello, { $user }.
hello-with-email-count = Hello, { $user }. You have { $emailCount } messages.
"#
        .to_string(),
    )
    .expect("Failed to parse FTL.");
    let mut bundle = FluentBundle::default();
    bundle.set_use_isolating(false);
    bundle.add_resource(res).expect("Failed to add a resource.");

    // simple hello
    let msg = bundle
        .get_message("hello")
        .expect("Failed to retrieve a message.");
    let value = msg.value().expect("Failed to retrieve a value.");

    let mut args = FluentArgs::new();
    args.set("user", "John");
    args.set("user", "Alice");
    let mut err = vec![];

    // Returns "Hello, John."
    assert_eq!(
        bundle.format_pattern(value, Some(&args), &mut err),
        "Hello, Alice."
    );

    // hello with email count
    let msg = bundle
        .get_message("hello-with-email-count")
        .expect("Failed to retrieve a message.");
    let value = msg.value().expect("Failed to retrieve a value.");

    let mut args = FluentArgs::new();
    args.set("user", "John");
    args.set("emailCount", 5);
    args.set("user", "Alice");
    args.set("emailCount", 7);
    let mut err = vec![];

    // Returns "Hello, Alice. You have 5 messages."
    assert_eq!(
        bundle.format_pattern(value, Some(&args), &mut err),
        "Hello, Alice. You have 7 messages."
    );
}
```