### PR TITLE
Allow optional arguments

### DIFF
--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -206,3 +206,15 @@ impl<'source> From<Cow<'source, str>> for FluentValue<'source> {
         FluentValue::String(s)
     }
 }
+
+impl<'source, T> From<Option<T>> for FluentValue<'source>
+where
+    T: Into<FluentValue<'source>>,
+{
+    fn from(s: Option<T>) -> Self {
+        match s {
+            Some(v) => v.into(),
+            None => FluentValue::None,
+        }
+    }
+}

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -211,8 +211,8 @@ impl<'source, T> From<Option<T>> for FluentValue<'source>
 where
     T: Into<FluentValue<'source>>,
 {
-    fn from(s: Option<T>) -> Self {
-        match s {
+    fn from(v: Option<T>) -> Self {
+        match v {
             Some(v) => v.into(),
             None => FluentValue::None,
         }

--- a/fluent-bundle/tests/optional_value.rs
+++ b/fluent-bundle/tests/optional_value.rs
@@ -1,0 +1,58 @@
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
+
+#[test]
+fn test_optional_value() {
+    let ftl_string = String::from(
+        "
+hello = { $title ->
+        [Miss] Hello, Miss. { $name }!
+        [Mr] Hello, Mr. { $name }!
+        [Mrs] Hello, Mrs. { $name }!
+        [Ms] Hello, Ms. { $name }!
+       *[Mx] Hello, Mx. { $name }!
+    }
+    ",
+    );
+
+    let res = FluentResource::try_new(ftl_string).expect("Could not parse an FTL string.");
+    let mut bundle = FluentBundle::default();
+    bundle.set_use_isolating(false);
+
+    bundle
+        .add_resource(res)
+        .expect("Failed to add FTL resources to the bundle.");
+
+    let msg = bundle.get_message("hello").expect("Message doesn't exist.");
+
+    let pattern = msg.value().expect("Message has no value.");
+
+    // Optional value that matches a non-default variant
+    let mut args = FluentArgs::new();
+    let title = Some("Mr");
+    args.set("title", title);
+    args.set("name", "John");
+
+    let mut errors = vec![];
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!("Hello, Mr. John!", &value);
+
+    // No value, use default variant
+    let mut args = FluentArgs::new();
+    let title: Option<&str> = None;
+    args.set("title", title);
+    args.set("name", "John");
+
+    let mut errors = vec![];
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!("Hello, Mx. John!", &value);
+
+    // Optional value that does not match any variant and therefore reverts to the default variant
+    let mut args = FluentArgs::new();
+    let title = Some(2);
+    args.set("title", title);
+    args.set("name", "John");
+
+    let mut errors = vec![];
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!("Hello, Mx. John!", &value);
+}


### PR DESCRIPTION
Any thoughts about implementing `From` for `Option`?:

```rust
impl<T> From<Option<T>> for FluentValue
where
    T: Into<FluentValue>
```

I find interesting to allow something like this:
```fluent
busy = { $gender ->
    [male] Occupé
    [female] Occupée
   *[other] Non disponible
}
```

```rust
let gender: Option<String> = None;
let mut args = FluentArgs::new();
args.set("gender", gender.into());
let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
```
