### PR TITLE
Add documentation to intl-memoizer

### DIFF
--- a/intl-memoizer/README.md
+++ b/intl-memoizer/README.md
@@ -13,35 +13,44 @@ APIs such as `PluralRules`, DateTimeFormat` etc. between all `FluentBundle` inst
 Usage
 -----
 
+The following is a high-level example of how this works, for running examples see
+the [docs](https://docs.rs/intl-memoizer/)
+
 ```rust
-use intl_memoizer::{IntlMemoizer, Memoizable};
-use unic_langid::langid;
-
-use intl_pluralrules::{PluralRules, PluralRuleType, PluralCategory};
-
-impl Memoizable for PluralRules {
-    type Args = (PluralRulesType,);
-    fn construct(lang: LanguageIdentifier, args: Self::Args) -> Self {
-      Self::new(lang, args.0)
-    }
+/// Internationalization formatter should implement the Memoizable trait.
+impl Memoizable for NumberFormat {
+  ...
 }
 
-fn main() {
-    let lang = langid!("en-US");
+// The main memoizer has weak references to all of the per-language memoizers.
+let mut memoizer = IntlMemoizer::default();
 
-    // A single memoizer for all languages
-    let mut memoizer = IntlMemoizer::new();
+// The formatter memoziation happens per-locale.
+let lang = "en-US".parse().expect("Failed to parse.");
+let lang_memoizer: Rc<IntlLangMemoizer> = memoizer.get_for_lang(en_us);
 
-    // A RefCell for a particular language to be used in all `FluentBundle`
-    // instances.
-    let mut en_us_memoizer = memoizer.get_for_lang(lang.clone());
+// Run the formatter
 
-    // Per-call borrow
-    let mut en_us_memoizer_borrow = en_us_memoizer.borrow_mut();
-    let cb = en_us_memoizer_borrow.get::<PluralRules>((PluralRulesType::Cardinal,));
-    assert_eq!(cb.select(1), PluralCategory::One);
-}
+let options: NumberFormatOptions {
+    minimum_fraction_digits: 3,
+    maximum_fraction_digits: 5,
+};
 
+// Format pi with the options. This will lazily construct the NumberFormat.
+let pi = lang_memoizer
+    .with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(3.141592653))
+    .unwrap()
+
+// The example formatter constructs a string with diagnostic information about
+// the configuration.
+assert_eq!(text, "3.14159");
+
+// Running it again will use the previous formatter.
+let two = lang_memoizer
+    .with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(2.0))
+    .unwrap()
+
+assert_eq!(text, "2.000");
 ```
 
 Get Involved

--- a/intl-memoizer/src/concurrent.rs
+++ b/intl-memoizer/src/concurrent.rs
@@ -1,6 +1,9 @@
+//! Contains thread-safe variants.
 use super::*;
 use std::sync::Mutex;
 
+/// A thread-safe version of the [`intl_memoizer::IntlLangMemoizer`](super::IntlLangMemoizer).
+/// See the single-thread version for more documentation.
 #[derive(Debug)]
 pub struct IntlLangMemoizer {
     lang: LanguageIdentifier,
@@ -8,6 +11,7 @@ pub struct IntlLangMemoizer {
 }
 
 impl IntlLangMemoizer {
+    /// Create a new [`IntlLangMemoizer`] that is unique to a specific [`LanguageIdentifier`]
     pub fn new(lang: LanguageIdentifier) -> Self {
         Self {
             lang,
@@ -15,6 +19,9 @@ impl IntlLangMemoizer {
         }
     }
 
+    /// Lazily initialize and run a formatter. See
+    /// [`intl_memoizer::IntlLangMemoizer::with_try_get`](../struct.IntlLangMemoizer.html#method.with_try_get)
+    /// for documentation.
     pub fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
     where
         Self: Sized,

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -189,7 +189,7 @@ impl IntlLangMemoizer {
         }
     }
 
-    /// `with_try_get` means `with` an international formatter, `try` and `get` a result.
+    /// `with_try_get` means `with` an internationalization formatter, `try` and `get` a result.
     /// The (potentially expensive) constructor for the formatter (such as PluralRules or
     /// DateTimeFormat) will be memoized and only constructed once for a given
     /// `construct_args`. After that the format operation can be run multiple times

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -22,7 +22,7 @@ pub trait Memoizable {
     /// Any errors that can occur during the construction process.
     type Error;
 
-    /// Construct a formatter. This maps the [`Self::Args`] type to the actual construcor
+    /// Construct a formatter. This maps the [`Self::Args`] type to the actual constructor
     /// for an intl formatter.
     fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error>
     where

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -1,3 +1,9 @@
+//! This crate contains a memoizer for internationalization formatters. Often it is
+//! expensive (in terms of performance and memory) to constuct a formatter, but then
+//! relatively cheap to run the format operation.
+//!
+//! The [IntlMemoizer] is the main struct that creates a per-locale [IntlLangMemoizer].
+
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -7,14 +13,166 @@ use unic_langid::LanguageIdentifier;
 
 pub mod concurrent;
 
+/// The trait that needs to be implemented for each intl formatter that needs to be
+/// memoized.
 pub trait Memoizable {
+    /// The arguments that are used to construct the formatter.
     type Args: 'static + Eq + Hash + Clone;
+
+    /// Any errors that can occur during the construction process.
     type Error;
+
+    /// Construct a formatter. This maps the [`Self::Args`] type to the actual construcor
+    /// for an intl formatter.
     fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error>
     where
         Self: std::marker::Sized;
 }
 
+/// The [`IntlLangMemoizer`] can memoize multiple constructed internationalization
+/// formatters, and their configuration for a single locale. For instance, given "en-US",
+/// a memorizer could retain 3 DateTimeFormat instances, and a PluralRules.
+///
+/// For memoizing with multiple locales, see [`IntlMemoizer`].
+///
+/// # Example
+///
+/// The code example does the following steps:
+///
+/// 1. Create a static counter
+/// 2. Create an `ExampleFormatter`
+/// 3. Implement [`Memoizable`] for `ExampleFormatter`.
+/// 4. Use `IntlLangMemoizer::with_try_get` to run `ExampleFormatter::format`
+/// 5. Demonstrate the memoization using the static counter
+///
+/// ```
+/// use intl_memoizer::{IntlLangMemoizer, Memoizable};
+/// use unic_langid::LanguageIdentifier;
+///
+/// // Create a static counter so that we can demonstrate the side effects of when
+/// // the memoizer re-constructs an API.
+///
+/// static mut INTL_EXAMPLE_CONSTRUCTS: u32 = 0;
+/// fn increment_constructs() {
+///     unsafe {
+///         INTL_EXAMPLE_CONSTRUCTS += 1;
+///     }
+/// }
+///
+/// fn get_constructs_count() -> u32 {
+///     unsafe { INTL_EXAMPLE_CONSTRUCTS }
+/// }
+///
+/// /// Create an example formatter, that doesn't really do anything useful. In a real
+/// /// implementation, this could be a PluralRules or DateTimeFormat struct.
+/// struct ExampleFormatter {
+///     lang: LanguageIdentifier,
+///     /// This is here to show how to initiate the API with an argument.
+///     prefix: String,
+/// }
+///
+/// impl ExampleFormatter {
+///     /// Perform an example format by printing information about the formatter
+///     /// configuration, and the arguments passed into the individual format operation.
+///     fn format(&self, example_string: &str) -> String {
+///         format!(
+///             "{} lang({}) string({})",
+///             self.prefix, self.lang, example_string
+///         )
+///     }
+/// }
+///
+/// /// Multiple classes of structs may be add1ed to the memoizer, with the restriction
+/// /// that they must implement the `Memoizable` trait.
+/// impl Memoizable for ExampleFormatter {
+///     /// The arguments will be passed into the constructor. Here a single `String`
+///     /// will be used as a prefix to the formatting operation.
+///     type Args = (String,);
+///
+///     /// If the construtor is fallible, than errors can be described here.
+///     type Error = ();
+///
+///     /// This function wires together the `Args` and `Error` type to construct
+///     /// the intl API. In our example, there is
+///     fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+///         // Keep track for example purposes that this was constructed.
+///         increment_constructs();
+///
+///         Ok(Self {
+///             lang,
+///             prefix: args.0,
+///         })
+///     }
+/// }
+///
+/// // The following demonstrates how these structs are actually used with the memoizer.
+///
+/// // Construct a new memoizer.
+/// let lang = "en-US".parse().expect("Failed to parse.");
+/// let memoizer = IntlLangMemoizer::new(lang);
+///
+/// // These arguments are passed into the constructor for `ExampleFormatter`.
+/// let construct_args = (String::from("prefix:"),);
+/// let message1 = "The format operation will run";
+/// let message2 = "ExampleFormatter will be re-used, when a second format is run";
+///
+/// // Run `IntlLangMemoizer::with_try_get`. The name of the method means "with" an
+/// // intl formatter, "try and get" the result. See the method documentation for
+/// // more details.
+///
+/// let result1 = memoizer
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///         intl_example.format(message1)
+///     });
+///
+/// // The memoized instance of `ExampleFormatter` will be re-used.
+/// let result2 = memoizer
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///         intl_example.format(message2)
+///     });
+///
+/// assert_eq!(
+///     result1.unwrap(),
+///     "prefix: lang(en-US) string(The format operation will run)"
+/// );
+/// assert_eq!(
+///     result2.unwrap(),
+///     "prefix: lang(en-US) string(ExampleFormatter will be re-used, when a second format is run)"
+/// );
+/// assert_eq!(
+///     get_constructs_count(),
+///     1,
+///     "The constructor was only run once."
+/// );
+///
+/// let construct_args = (String::from("re-init:"),);
+///
+/// // Since the constructor args changed, `ExampleFormatter` will be re-constructed.
+/// let result1 = memoizer
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///         intl_example.format(message1)
+///     });
+///
+/// // The memoized instance of `ExampleFormatter` will be re-used.
+/// let result2 = memoizer
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///         intl_example.format(message2)
+///     });
+///
+/// assert_eq!(
+///     result1.unwrap(),
+///     "re-init: lang(en-US) string(The format operation will run)"
+/// );
+/// assert_eq!(
+///     result2.unwrap(),
+///     "re-init: lang(en-US) string(ExampleFormatter will be re-used, when a second format is run)"
+/// );
+/// assert_eq!(
+///     get_constructs_count(),
+///     2,
+///     "The constructor was invalidated and ran again."
+/// );
+/// ```
 #[derive(Debug)]
 pub struct IntlLangMemoizer {
     lang: LanguageIdentifier,
@@ -22,6 +180,8 @@ pub struct IntlLangMemoizer {
 }
 
 impl IntlLangMemoizer {
+    /// Create a new [`IntlLangMemoizer`] that is unique to a specific
+    /// [`LanguageIdentifier`]
     pub fn new(lang: LanguageIdentifier) -> Self {
         Self {
             lang,
@@ -29,7 +189,23 @@ impl IntlLangMemoizer {
         }
     }
 
-    pub fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
+    /// `with_try_get` means `with` an international formatter, `try` and `get` a result.
+    /// The (potentially expensive) constructor for the formatter (such as PluralRules or
+    /// DateTimeFormat) will be memoized and only constructed once for a given
+    /// `construct_args`. After that the format operation can be run multiple times
+    /// inexpensively.
+    ///
+    /// The first generic argument `I` must be provided, but the `R` and `U` will be
+    /// deduced by the typing of the `callback` argument that is provided.
+    ///
+    /// I - The memoizable intl object, for instance a `PluralRules` instance. This
+    ///     must implement the Memoizable trait.
+    ///
+    /// R - The return result from the callback `U`.
+    ///
+    /// U - The callback function. Takes an instance of `I` as the first parameter and
+    ///     returns the R value.
+    pub fn with_try_get<I, R, U>(&self, construct_args: I::Args, callback: U) -> Result<R, I::Error>
     where
         Self: Sized,
         I: Memoizable + 'static,
@@ -43,23 +219,117 @@ impl IntlLangMemoizer {
             .entry::<HashMap<I::Args, I>>()
             .or_insert_with(HashMap::new);
 
-        let e = match cache.entry(args.clone()) {
+        let e = match cache.entry(construct_args.clone()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let val = I::construct(self.lang.clone(), args)?;
+                let val = I::construct(self.lang.clone(), construct_args)?;
                 entry.insert(val)
             }
         };
-        Ok(cb(e))
+        Ok(callback(e))
     }
 }
 
+/// [`IntlMemoizer`] is designed to handle lazily-initialized references to
+/// internationalization formatters.
+///
+/// Constructing a new formatter is often expensive in terms of memory and performance,
+/// and the instance is often read-only during its lifetime. The format operations in
+/// comparison are relatively cheap.
+///
+/// Because of this relationship, it can be helpful to memoize the constructors, and
+/// re-use them across multiple format operations. This strategy is used where all
+/// instances of intl APIs such as `PluralRules`, `DateTimeFormat` etc. are memoized
+/// between all `FluentBundle` instances.
+///
+/// # Example
+///
+/// For a more complete example of the memoization, see the [`IntlLangMemoizer`] documentation.
+/// This example provides a higher-level overview.
+///
+/// ```
+/// # use intl_memoizer::{IntlMemoizer, IntlLangMemoizer, Memoizable};
+/// # use unic_langid::LanguageIdentifier;
+/// # use std::rc::Rc;
+/// #
+/// # struct ExampleFormatter {
+/// #     lang: LanguageIdentifier,
+/// #     prefix: String,
+/// # }
+/// #
+/// # impl ExampleFormatter {
+/// #     fn format(&self, example_string: &str) -> String {
+/// #         format!(
+/// #             "{} lang({}) string({})",
+/// #             self.prefix, self.lang, example_string
+/// #         )
+/// #     }
+/// # }
+/// #
+/// # impl Memoizable for ExampleFormatter {
+/// #     type Args = (String,);
+/// #     type Error = ();
+/// #     fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+/// #         Ok(Self {
+/// #             lang,
+/// #             prefix: args.0,
+/// #         })
+/// #     }
+/// # }
+/// #
+/// let mut memoizer = IntlMemoizer::default();
+///
+/// // The memoziation happens per-locale.
+/// let en_us = "en-US".parse().expect("Failed to parse.");
+/// let en_us_memoizer: Rc<IntlLangMemoizer> = memoizer.get_for_lang(en_us);
+///
+/// // These arguments are passed into the constructor for `ExampleFormatter`. The
+/// // construct_args will be used for determining the memoization, but the message
+/// // can be different and re-use the constructed instance.
+/// let construct_args = (String::from("prefix:"),);
+/// let message = "The format operation will run";
+///
+/// // Use the `ExampleFormater` from the `IntlLangMemoizer` example. It returns a
+/// // string that demonstrates the configuration of the formatter. This step will
+/// // construct a new formatter if needed, and run the format operation.
+/// //
+/// // See `IntlLangMemoizer` for more details on this step.
+/// let en_us_result = en_us_memoizer
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///         intl_example.format(message)
+///     });
+///
+/// // The example formatter constructs a string with diagnostic information about
+/// // the configuration.
+/// assert_eq!(
+///     en_us_result.unwrap(),
+///     "prefix: lang(en-US) string(The format operation will run)"
+/// );
+///
+/// // The process can be repeated for a new locale.
+///
+/// let de_de = "de-DE".parse().expect("Failed to parse.");
+/// let de_de_memoizer: Rc<IntlLangMemoizer> = memoizer.get_for_lang(de_de);
+///
+/// let de_de_result = de_de_memoizer
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///         intl_example.format(message)
+///     });
+///
+/// assert_eq!(
+///     de_de_result.unwrap(),
+///     "prefix: lang(de-DE) string(The format operation will run)"
+/// );
+/// ```
 #[derive(Default)]
 pub struct IntlMemoizer {
     map: HashMap<LanguageIdentifier, Weak<IntlLangMemoizer>>,
 }
 
 impl IntlMemoizer {
+    /// Get a [`IntlLangMemoizer`] for a given language. If one does not exist for
+    /// a locale, it will be constructed and weakly retained. See [`IntlLangMemoizer`]
+    /// for more detailed documentation how to use it.
     pub fn get_for_lang(&mut self, lang: LanguageIdentifier) -> Rc<IntlLangMemoizer> {
         match self.map.entry(lang.clone()) {
             Entry::Vacant(empty) => {

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -19,7 +19,7 @@ pub trait Memoizable {
     /// Type of the arguments that are used to construct the formatter.
     type Args: 'static + Eq + Hash + Clone;
 
-    /// Any errors that can occur during the construction process.
+    /// Type of any errors that can occur during the construction process.
     type Error;
 
     /// Construct a formatter. This maps the [`Self::Args`] type to the actual constructor

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -16,7 +16,7 @@ pub mod concurrent;
 /// The trait that needs to be implemented for each intl formatter that needs to be
 /// memoized.
 pub trait Memoizable {
-    /// The arguments that are used to construct the formatter.
+    /// Type of the arguments that are used to construct the formatter.
     type Args: 'static + Eq + Hash + Clone;
 
     /// Any errors that can occur during the construction process.


### PR DESCRIPTION
I also included example usages of the memoizer. The README.md would not compile, so I moved the example to rust docs. The README.md now includes an example which is more pseudo-code to explain the usage conceptually.