### PR TITLE
Change the resource ids to be a Set rather than a Vec

### DIFF
--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3"
 async-trait = "0.1"
 unic-langid = { version = "0.9" }
 once_cell = "1.9"
+rustc-hash = "1"
 
 [dev-dependencies]
 fluent-langneg = "0.13"

--- a/fluent-fallback/examples/simple-fallback.rs
+++ b/fluent-fallback/examples/simple-fallback.rs
@@ -28,6 +28,7 @@ use fluent_fallback::{
 };
 use fluent_langneg::{negotiate_languages, NegotiationStrategy};
 
+use rustc_hash::FxHashSet;
 use unic_langid::{langid, LanguageIdentifier};
 
 /// This helper struct holds the scheme for converting
@@ -111,7 +112,7 @@ fn main() {
     let bundles = get_resource_manager();
 
     let loc = Localization::with_env(
-        L10N_RESOURCES.iter().map(|&res| res.into()).collect(),
+        L10N_RESOURCES.iter().map(|&res| res.into()),
         true,
         app_locales,
         bundles,
@@ -168,7 +169,7 @@ fn collatz(n: isize) -> isize {
 struct BundleIter {
     res_path_scheme: String,
     locales: <Vec<LanguageIdentifier> as IntoIterator>::IntoIter,
-    res_ids: Vec<ResourceId>,
+    res_ids: FxHashSet<ResourceId>,
 }
 
 impl Iterator for BundleIter {
@@ -225,7 +226,7 @@ impl BundleGenerator for Bundles {
     fn bundles_iter(
         &self,
         locales: std::vec::IntoIter<LanguageIdentifier>,
-        res_ids: Vec<ResourceId>,
+        res_ids: FxHashSet<ResourceId>,
     ) -> Self::Iter {
         BundleIter {
             res_path_scheme: self.res_path_scheme.to_string_lossy().to_string(),

--- a/fluent-fallback/src/bundles.rs
+++ b/fluent-fallback/src/bundles.rs
@@ -6,6 +6,7 @@ use crate::{
     types::{L10nAttribute, L10nKey, L10nMessage, ResourceId},
 };
 use fluent_bundle::{FluentArgs, FluentBundle, FluentError};
+use rustc_hash::FxHashSet;
 use std::borrow::Cow;
 
 pub enum BundlesInner<G>
@@ -50,7 +51,7 @@ impl<G> Bundles<G>
 where
     G: BundleGenerator,
 {
-    pub fn new<P>(sync: bool, res_ids: Vec<ResourceId>, generator: &G, provider: &P) -> Self
+    pub fn new<P>(sync: bool, res_ids: FxHashSet<ResourceId>, generator: &G, provider: &P) -> Self
     where
         G: BundleGenerator<LocalesIter = P::Iter>,
         P: LocalesProvider,

--- a/fluent-fallback/src/generator.rs
+++ b/fluent-fallback/src/generator.rs
@@ -1,5 +1,6 @@
 use fluent_bundle::{FluentBundle, FluentError, FluentResource};
 use futures::Stream;
+use rustc_hash::FxHashSet;
 use std::borrow::Borrow;
 use unic_langid::LanguageIdentifier;
 
@@ -22,14 +23,18 @@ pub trait BundleGenerator {
     type Iter: Iterator<Item = FluentBundleResult<Self::Resource>>;
     type Stream: Stream<Item = FluentBundleResult<Self::Resource>>;
 
-    fn bundles_iter(&self, _locales: Self::LocalesIter, _res_ids: Vec<ResourceId>) -> Self::Iter {
+    fn bundles_iter(
+        &self,
+        _locales: Self::LocalesIter,
+        _res_ids: FxHashSet<ResourceId>,
+    ) -> Self::Iter {
         unimplemented!();
     }
 
     fn bundles_stream(
         &self,
         _locales: Self::LocalesIter,
-        _res_ids: Vec<ResourceId>,
+        _res_ids: FxHashSet<ResourceId>,
     ) -> Self::Stream {
         unimplemented!();
     }

--- a/fluent-fallback/src/types.rs
+++ b/fluent-fallback/src/types.rs
@@ -28,7 +28,7 @@ pub struct L10nMessage<'l> {
     pub attributes: Vec<L10nAttribute<'l>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ResourceType {
     /// This is a required resource.
     ///
@@ -53,7 +53,7 @@ pub enum ResourceType {
 }
 
 /// A resource identifier for a localization resource.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct ResourceId {
     /// The resource identifier.
     pub value: String,

--- a/fluent-fallback/tests/localization_test.rs
+++ b/fluent-fallback/tests/localization_test.rs
@@ -488,3 +488,23 @@ async fn localization_handle_state_changes_mid_async() {
 
     bundles.format_value("key", None, &mut errors).await;
 }
+
+#[test]
+#[should_panic]
+fn localization_duplicate_resources() {
+    let resource_ids: Vec<ResourceId> =
+        vec!["test.ftl".into(), "test2.ftl".into(), "test2.ftl".into()];
+    let locales = Locales::new(vec![langid!("pl"), langid!("en-US")]);
+    let res_mgr = ResourceManager;
+    let mut errors = vec![];
+
+    let loc = Localization::with_env(resource_ids, true, locales, res_mgr);
+    let bundles = loc.bundles();
+
+    let value = bundles
+        .format_value_sync("hello-world", None, &mut errors)
+        .unwrap();
+    assert_eq!(value, Some(Cow::Borrowed("Hello World [pl]")));
+
+    assert_eq!(errors.len(), 0, "There were no errors");
+}

--- a/fluent-fallback/tests/localization_test.rs
+++ b/fluent-fallback/tests/localization_test.rs
@@ -11,6 +11,7 @@ use fluent_fallback::{
     types::{L10nKey, ResourceId},
     Localization, LocalizationError,
 };
+use rustc_hash::FxHashSet;
 use std::cell::RefCell;
 use std::rc::Rc;
 use unic_langid::{langid, LanguageIdentifier};
@@ -55,7 +56,7 @@ impl LocalesProvider for Locales {
 // lack of GATs, these have to own members instead of taking slices.
 struct BundleIter {
     locales: <Vec<LanguageIdentifier> as IntoIterator>::IntoIter,
-    res_ids: Vec<ResourceId>,
+    res_ids: FxHashSet<ResourceId>,
 }
 
 impl Iterator for BundleIter {
@@ -132,11 +133,19 @@ impl BundleGenerator for ResourceManager {
     type Iter = BundleIter;
     type Stream = BundleIter;
 
-    fn bundles_iter(&self, locales: Self::LocalesIter, res_ids: Vec<ResourceId>) -> Self::Iter {
+    fn bundles_iter(
+        &self,
+        locales: Self::LocalesIter,
+        res_ids: FxHashSet<ResourceId>,
+    ) -> Self::Iter {
         BundleIter { locales, res_ids }
     }
 
-    fn bundles_stream(&self, locales: Self::LocalesIter, res_ids: Vec<ResourceId>) -> Self::Stream {
+    fn bundles_stream(
+        &self,
+        locales: Self::LocalesIter,
+        res_ids: FxHashSet<ResourceId>,
+    ) -> Self::Stream {
         BundleIter { locales, res_ids }
     }
 }
@@ -490,7 +499,6 @@ async fn localization_handle_state_changes_mid_async() {
 }
 
 #[test]
-#[should_panic]
 fn localization_duplicate_resources() {
     let resource_ids: Vec<ResourceId> =
         vec!["test.ftl".into(), "test2.ftl".into(), "test2.ftl".into()];

--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -22,6 +22,7 @@ fluent-fallback = { version = "0.6.0", path = "../fluent-fallback" }
 unic-langid = "0.9"
 elsa = "1.5"
 futures = "0.3"
+rustc-hash = "1"
 
 [dev-dependencies]
 unic-langid = { version = "0.9", features = ["macros"]}


### PR DESCRIPTION
See [Bug 1755216](https://bugzilla.mozilla.org/show_bug.cgi?id=1755216) for a larger discussion, but this changes the behavior so that when multiple `ResourceId`s are added, they do not trigger a Fluent error. It changes the behavior to a noop, since the behavior of the translated messages doesn't actually change.