### PR TITLE
Add a github workflow to run rust fmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ name: Rustfmt
 on:
   # Triggers the workflow on push request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   format:


### PR DESCRIPTION
Resolves #288 

Tested locally with act:

```
[Rustfmt/format]   🐳  docker exec cmd=[node /var/run/act/actions/mbrobbel-rustfmt-check@master/dist/index.js] user= workdir=
| [command]/root/.cargo/bin/cargo + fmt -- -l
[Rustfmt/format]   ✅  Success - Main mbrobbel/rustfmt-check@master
[Rustfmt/format] 🏁  Job succeeded
```