### PR TITLE
Fixed up clippy warnrings/errors

### DIFF
--- a/fluent-bundle/benches/resolver.rs
+++ b/fluent-bundle/benches/resolver.rs
@@ -25,7 +25,7 @@ fn get_strings(tests: &[&'static str]) -> HashMap<&'static str, String> {
         let path = format!("./benches/{}.ftl", test);
         ftl_strings.insert(*test, read_file(&path).expect("Couldn't load file"));
     }
-    return ftl_strings;
+    ftl_strings
 }
 
 fn get_ids(res: &FluentResource) -> Vec<String> {
@@ -62,7 +62,7 @@ fn add_functions<R>(name: &'static str, bundle: &mut FluentBundle<R>) {
         "preferences" => {
             bundle
                 .add_function("PLATFORM", |_args, _named_args| {
-                    return "linux".into();
+                    "linux".into()
                 })
                 .expect("Failed to add a function to the bundle.");
         }
@@ -133,7 +133,7 @@ fn resolver_bench(c: &mut Criterion) {
                             bundle.write_pattern(&mut s, attr.value(), args.as_ref(), &mut errors);
                         s.clear();
                     }
-                    assert!(errors.len() == 0, "Resolver errors: {:#?}", errors);
+                    assert!(errors.is_empty(), "Resolver errors: {:#?}", errors);
                 }
             })
         });
@@ -156,7 +156,7 @@ fn resolver_bench(c: &mut Criterion) {
                     for attr in msg.attributes() {
                         let _ = bundle.format_pattern(attr.value(), args.as_ref(), &mut errors);
                     }
-                    assert!(errors.len() == 0, "Resolver errors: {:#?}", errors);
+                    assert!(errors.is_empty(), "Resolver errors: {:#?}", errors);
                 }
             })
         });

--- a/fluent-bundle/benches/resolver_iai.rs
+++ b/fluent-bundle/benches/resolver_iai.rs
@@ -9,7 +9,7 @@ fn add_functions<R>(name: &'static str, bundle: &mut FluentBundle<R>) {
         "preferences" => {
             bundle
                 .add_function("PLATFORM", |_args, _named_args| {
-                    return "linux".into();
+                    "linux".into()
                 })
                 .expect("Failed to add a function to the bundle.");
         }
@@ -71,7 +71,7 @@ fn iai_resolve_preferences() {
                     .expect("Failed to write a pattern.");
                 s.clear();
             }
-            assert!(errors.len() == 0, "Resolver errors: {:#?}", errors);
+            assert!(errors.is_empty(), "Resolver errors: {:#?}", errors);
         }
     }
 }

--- a/fluent-bundle/examples/custom_formatter.rs
+++ b/fluent-bundle/examples/custom_formatter.rs
@@ -10,7 +10,7 @@ use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
 
 fn custom_formatter<M: MemoizerKind>(num: &FluentValue, _intls: &M) -> Option<String> {
     match num {
-        FluentValue::Number(n) => Some(format!("CUSTOM({})", n.value).into()),
+        FluentValue::Number(n) => Some(format!("CUSTOM({})", n.value)),
         _ => None,
     }
 }
@@ -59,7 +59,7 @@ key-var-with-arg = Here is a variable formatted with an argument { NUMBER($num, 
         .get_message("key-implicit")
         .expect("Message doesn't exist.");
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     assert_eq!(value, "Here is an implicitly encoded number: 5.");
     println!("{}", value);
 
@@ -72,7 +72,7 @@ key-var-with-arg = Here is a variable formatted with an argument { NUMBER($num, 
         .get_message("key-implicit")
         .expect("Message doesn't exist.");
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     assert_eq!(value, "Here is an implicitly encoded number: CUSTOM(5).");
     println!("{}", value);
 
@@ -82,7 +82,7 @@ key-var-with-arg = Here is a variable formatted with an argument { NUMBER($num, 
         .get_message("key-explicit")
         .expect("Message doesn't exist.");
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     assert_eq!(value, "Here is an explicitly encoded number: CUSTOM(5).");
     println!("{}", value);
 
@@ -92,7 +92,7 @@ key-var-with-arg = Here is a variable formatted with an argument { NUMBER($num, 
     let pattern = msg.value().expect("Message has no value.");
     let mut args = FluentArgs::new();
     args.set("num", FluentValue::from(-15));
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     assert_eq!(
         value,
         "Here is an implicitly encoded variable: CUSTOM(-15)."
@@ -105,7 +105,7 @@ key-var-with-arg = Here is a variable formatted with an argument { NUMBER($num, 
     let pattern = msg.value().expect("Message has no value.");
     let mut args = FluentArgs::new();
     args.set("num", FluentValue::from(-15));
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     assert_eq!(
         value,
         "Here is an explicitly encoded variable: CUSTOM(-15)."
@@ -129,7 +129,7 @@ key-var-with-arg = Here is a variable formatted with an argument { NUMBER($num, 
         },
     );
     args.set("num", num);
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
 
     // Notice, that since we specificed minimum and maximum fraction digits options
     // to be 1 and 8 when construction the argument, and then the minimum fraction

--- a/fluent-bundle/examples/external_arguments.rs
+++ b/fluent-bundle/examples/external_arguments.rs
@@ -28,13 +28,13 @@ unread-emails =
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     println!("{}", value);
 
     let msg = bundle.get_message("ref").expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     println!("{}", value);
 
     let mut args = FluentArgs::new();
@@ -45,6 +45,6 @@ unread-emails =
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     println!("{}", value);
 }

--- a/fluent-bundle/examples/functions.rs
+++ b/fluent-bundle/examples/functions.rs
@@ -17,7 +17,7 @@ fn main() {
     // Test for a simple function that returns a string
     bundle
         .add_function("HELLO", |_args, _named_args| {
-            return "I'm a function!".into();
+            "I'm a function!".into()
         })
         .expect("Failed to add a function to the bundle.");
 
@@ -61,7 +61,7 @@ fn main() {
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     assert_eq!(&value, "Hey there! \u{2068}I'm a function!\u{2069}");
 
     let msg = bundle
@@ -69,7 +69,7 @@ fn main() {
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     assert_eq!(&value, "The answer to life, the universe, and everything");
 
     let msg = bundle
@@ -77,6 +77,6 @@ fn main() {
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     assert_eq!(&value, "All your base belong to us");
 }

--- a/fluent-bundle/examples/hello.rs
+++ b/fluent-bundle/examples/hello.rs
@@ -13,6 +13,6 @@ fn main() {
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     assert_eq!(&value, "Hello, world!");
 }

--- a/fluent-bundle/examples/message_reference.rs
+++ b/fluent-bundle/examples/message_reference.rs
@@ -20,7 +20,7 @@ bazbar = { baz } Bar
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     println!("{}", value);
 
     let msg = bundle
@@ -28,6 +28,6 @@ bazbar = { baz } Bar
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     println!("{}", value);
 }

--- a/fluent-bundle/examples/selector.rs
+++ b/fluent-bundle/examples/selector.rs
@@ -25,7 +25,7 @@ hello-world2 = Hello { $name ->
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     println!("{}", value);
 
     let mut args = FluentArgs::new();
@@ -36,6 +36,6 @@ hello-world2 = Hello { $name ->
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     println!("{}", value);
 }

--- a/fluent-bundle/examples/simple-app.rs
+++ b/fluent-bundle/examples/simple-app.rs
@@ -69,7 +69,7 @@ fn get_available_locales() -> Result<Vec<LanguageIdentifier>, io::Error> {
             }
         }
     }
-    return Ok(locales);
+    Ok(locales)
 }
 
 static L10N_RESOURCES: &[&str] = &["simple.ftl"];
@@ -82,7 +82,7 @@ fn main() {
     //    take the second argument as a comma-separated
     //    list of requested locales.
     let requested = args.get(2).map_or(vec![], |arg| {
-        arg.split(",")
+        arg.split(',')
             .map(|s| -> LanguageIdentifier { s.parse().expect("Parsing locale failed.") })
             .collect()
     });
@@ -126,7 +126,7 @@ fn main() {
     match args.get(1) {
         Some(input) => {
             // 7.1. Cast it to a number.
-            match isize::from_str(&input) {
+            match isize::from_str(input) {
                 Ok(i) => {
                     // 7.2. Construct a map of arguments
                     //      to format the message.
@@ -139,7 +139,7 @@ fn main() {
                         .get_message("response-msg")
                         .expect("Message doesn't exist.");
                     let pattern = msg.value().expect("Message has no value.");
-                    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+                    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
                     println!("{}", value);
                 }
                 Err(err) => {
@@ -151,7 +151,7 @@ fn main() {
                         .get_message("input-parse-error")
                         .expect("Message doesn't exist.");
                     let pattern = msg.value().expect("Message has no value.");
-                    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+                    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
                     println!("{}", value);
                 }
             }
@@ -162,7 +162,7 @@ fn main() {
                 .get_message("missing-arg-error")
                 .expect("Message doesn't exist.");
             let pattern = msg.value().expect("Message has no value.");
-            let value = bundle.format_pattern(&pattern, None, &mut errors);
+            let value = bundle.format_pattern(pattern, None, &mut errors);
             println!("{}", value);
         }
     }

--- a/fluent-bundle/src/entry.rs
+++ b/fluent-bundle/src/entry.rs
@@ -35,7 +35,7 @@ pub trait GetEntry {
     fn get_entry_function(&self, id: &str) -> Option<&FluentFunction>;
 }
 
-impl<'bundle, R: Borrow<FluentResource>, M> GetEntry for FluentBundle<R, M> {
+impl<R: Borrow<FluentResource>, M> GetEntry for FluentBundle<R, M> {
     fn get_entry_message(&self, id: &str) -> Option<&ast::Message<&str>> {
         self.entries.get(id).and_then(|ref entry| match entry {
             Entry::Message((resource_idx, entry_idx)) => {

--- a/fluent-bundle/src/errors.rs
+++ b/fluent-bundle/src/errors.rs
@@ -2,7 +2,7 @@ use crate::resolver::ResolverError;
 use fluent_syntax::parser::ParserError;
 use std::error::Error;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EntryKind {
     Message,
     Term,
@@ -23,7 +23,7 @@ impl std::fmt::Display for EntryKind {
 ///
 /// It contains three main types of errors that may come up
 /// during runtime use of the fluent-bundle crate.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum FluentError {
     /// An error which occurs when
     /// [`FluentBundle::add_resource`](crate::bundle::FluentBundle::add_resource)

--- a/fluent-bundle/src/resolver/errors.rs
+++ b/fluent-bundle/src/resolver/errors.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 /// Maps an [`InlineExpression`] into the kind of reference, with owned strings
 /// that identify the expression. This makes it so that the [`InlineExpression`] can
 /// be used to generate an error string.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ReferenceKind {
     Function {
         id: String,
@@ -49,7 +49,7 @@ where
 
 /// Errors generated during the process of resolving a fluent message into a string.
 /// This process takes place in the `write` method of the `WriteValue` trait.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ResolverError {
     Reference(ReferenceKind),
     NoValue(String),

--- a/fluent-bundle/tests/function.rs
+++ b/fluent-bundle/tests/function.rs
@@ -63,7 +63,7 @@ liked-count2 = { NUMBER($num) ->
 
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     assert_eq!("\u{2068}1\u{2069} people liked your message", &value);
 
     // 3. Example with passing number, but without NUMBER call
@@ -75,7 +75,7 @@ liked-count2 = { NUMBER($num) ->
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     assert_eq!("One person liked your message", &value);
 
     // 4. Example with NUMBER call
@@ -87,7 +87,7 @@ liked-count2 = { NUMBER($num) ->
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     assert_eq!("One person liked your message", &value);
 
     // 5. Example with NUMBER call from number
@@ -99,6 +99,6 @@ liked-count2 = { NUMBER($num) ->
         .expect("Message doesn't exist.");
     let mut errors = vec![];
     let pattern = msg.value().expect("Message has no value.");
-    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     assert_eq!("One person liked your message", &value);
 }

--- a/fluent-bundle/tests/helpers/mod.rs
+++ b/fluent-bundle/tests/helpers/mod.rs
@@ -88,7 +88,7 @@ pub fn get_defaults(path: &str) -> Result<TestDefaults, io::Error> {
     Ok(serde_yaml::from_str(&s).expect("Parsing YAML failed."))
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TestBundle {
     pub name: Option<String>,
@@ -102,7 +102,7 @@ pub struct TestBundle {
     pub errors: Vec<TestError>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TestResource {
     pub name: Option<String>,
@@ -120,7 +120,7 @@ pub struct TestSetup {
     pub resources: Vec<TestResource>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TestError {
     #[serde(rename = "type")]
@@ -186,7 +186,7 @@ pub struct TestFixture {
     pub suites: Vec<TestSuite>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct BundleDefaults {
     #[serde(rename = "useIsolating")]
@@ -195,7 +195,7 @@ pub struct BundleDefaults {
     pub locales: Option<Vec<String>>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TestDefaults {
     pub bundle: BundleDefaults,

--- a/fluent-bundle/tests/resolver_fixtures.rs
+++ b/fluent-bundle/tests/resolver_fixtures.rs
@@ -17,7 +17,7 @@ use unic_langid::LanguageIdentifier;
 use helpers::*;
 
 fn transform_example(s: &str) -> Cow<str> {
-    s.replace("a", "A").into()
+    s.replace('a', "A").into()
 }
 
 #[derive(Clone)]
@@ -57,15 +57,15 @@ impl Scope {
                     .name
                     .as_ref()
                     .cloned()
-                    .unwrap_or_else(|| generate_random_hash());
-                let bundle = create_bundle(Some(b), &defaults, &available_resources);
+                    .unwrap_or_else(generate_random_hash);
+                let bundle = create_bundle(Some(b), defaults, &available_resources);
                 bundles.insert(name, bundle);
             }
         }
         if bundles.is_empty() {
             let bundle = create_bundle(None, defaults, &available_resources);
             let name = generate_random_hash();
-            bundles.insert(name.clone(), bundle);
+            bundles.insert(name, bundle);
         }
         bundles
     }
@@ -83,7 +83,7 @@ fn generate_random_hash() -> String {
 
 fn test_fixture(fixture: &TestFixture, defaults: &Option<TestDefaults>) {
     for suite in &fixture.suites {
-        test_suite(&suite, defaults, Scope(vec![]));
+        test_suite(suite, defaults, Scope(vec![]));
     }
 }
 
@@ -102,7 +102,7 @@ fn create_bundle(
                 .and_then(|defaults| defaults.bundle.locales.as_ref())
         })
         .map(|locs| {
-            locs.into_iter()
+            locs.iter()
                 .map(|s| s.parse().expect("Parsing failed."))
                 .collect()
         })
@@ -137,7 +137,7 @@ fn create_bundle(
                 "CONCAT" => bundle.add_function(f.as_str(), |args, _name_args| {
                     args.iter()
                         .fold(String::new(), |acc, x| match x {
-                            FluentValue::String(s) => acc + &s.to_string(),
+                            FluentValue::String(s) => acc + s,
                             FluentValue::Number(n) => acc + &n.value.to_string(),
                             _ => acc,
                         })
@@ -267,49 +267,41 @@ fn test_test(test: &Test, defaults: &Option<TestDefaults>, mut scope: Scope) {
                 assert.id,
                 scope.get_path()
             );
-        } else {
-            if let Some(ref expected_value) = assert.value {
-                let msg = bundle.get_message(&assert.id).expect(&format!(
-                    "Failed to retrieve message `{}` in {}.",
-                    &assert.id,
-                    scope.get_path()
-                ));
-                let val = if let Some(ref attr) = assert.attribute {
-                    msg.get_attribute(attr.as_str())
-                        .expect(&format!(
-                            "Failed to retrieve an attribute of a message {}.{}.",
-                            assert.id, attr
-                        ))
-                        .value()
-                } else {
-                    msg.value().expect(&format!(
-                        "Failed to retrieve a value of a message {}.",
-                        assert.id
-                    ))
-                };
-
-                let args: Option<FluentArgs> = assert.args.as_ref().map(|args| {
-                    args.iter()
-                        .map(|(k, v)| {
-                            let val: FluentValue = match v {
-                                TestArgumentValue::String(s) => s.as_str().into(),
-                                TestArgumentValue::Number(n) => n.into(),
-                            };
-                            (k.as_str(), val)
-                        })
-                        .collect()
-                });
-                let value = bundle.format_pattern(&val, args.as_ref(), &mut errors);
-                assert_eq!(
-                    &value,
-                    expected_value,
-                    "Values don't match in {}",
-                    scope.get_path()
-                );
-                test_errors(&errors, Some(&assert.errors));
+        } else if let Some(ref expected_value) = assert.value {
+            let msg = bundle.get_message(&assert.id).unwrap_or_else(|| panic!("Failed to retrieve message `{}` in {}.",
+                &assert.id,
+                scope.get_path()));
+            let val = if let Some(ref attr) = assert.attribute {
+                msg.get_attribute(attr.as_str())
+                    .unwrap_or_else(|| panic!("Failed to retrieve an attribute of a message {}.{}.",
+                        assert.id, attr))
+                    .value()
             } else {
-                panic!("Value field expected.");
-            }
+                msg.value().unwrap_or_else(|| panic!("Failed to retrieve a value of a message {}.",
+                    assert.id))
+            };
+
+            let args: Option<FluentArgs> = assert.args.as_ref().map(|args| {
+                args.iter()
+                    .map(|(k, v)| {
+                        let val: FluentValue = match v {
+                            TestArgumentValue::String(s) => s.as_str().into(),
+                            TestArgumentValue::Number(n) => n.into(),
+                        };
+                        (k.as_str(), val)
+                    })
+                    .collect()
+            });
+            let value = bundle.format_pattern(val, args.as_ref(), &mut errors);
+            assert_eq!(
+                &value,
+                expected_value,
+                "Values don't match in {}",
+                scope.get_path()
+            );
+            test_errors(&errors, Some(&assert.errors));
+        } else {
+            panic!("Value field expected.");
         }
     }
 }
@@ -317,7 +309,7 @@ fn test_test(test: &Test, defaults: &Option<TestDefaults>, mut scope: Scope) {
 fn test_errors(errors: &[FluentError], reference: Option<&[TestError]>) {
     let reference = reference.unwrap_or(&[]);
     assert_eq!(errors.len(), reference.len());
-    for (error, reference) in errors.into_iter().zip(reference) {
+    for (error, reference) in errors.iter().zip(reference) {
         match error {
             FluentError::ResolverError(err) => match err {
                 ResolverError::Reference(_) => {

--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -133,7 +133,7 @@ fn fluent_number_style() {
     let num = FluentNumber::new(0.2, opts.clone());
     assert_eq!(num.as_string(), "0.200");
 
-    let num = FluentNumber::new(2.0, opts.clone());
+    let num = FluentNumber::new(2.0, opts);
     assert_eq!(num.as_string(), "2.000");
 }
 

--- a/fluent-fallback/examples/simple-fallback.rs
+++ b/fluent-fallback/examples/simple-fallback.rs
@@ -71,7 +71,7 @@ fn resolve_app_locales<'l>(args: &[String]) -> Vec<LanguageIdentifier> {
     let available = get_available_locales().expect("Retrieving available locales failed.");
 
     let requested: Vec<LanguageIdentifier> = args.get(2).map_or(vec![], |arg| {
-        arg.split(",")
+        arg.split(',')
             .map(|s| s.parse().expect("Parsing locale failed."))
             .collect()
     });
@@ -122,7 +122,7 @@ fn main() {
     let mut errors = vec![];
 
     match args.get(1) {
-        Some(input) => match isize::from_str(&input) {
+        Some(input) => match isize::from_str(input) {
             Ok(i) => {
                 let mut args = FluentArgs::new();
                 args.set("input", i);

--- a/fluent-fallback/src/errors.rs
+++ b/fluent-fallback/src/errors.rs
@@ -2,7 +2,7 @@ use fluent_bundle::FluentError;
 use std::error::Error;
 use unic_langid::LanguageIdentifier;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum LocalizationError {
     Bundle {
         error: FluentError,

--- a/fluent-fallback/src/types.rs
+++ b/fluent-fallback/src/types.rs
@@ -53,7 +53,7 @@ pub enum ResourceType {
 }
 
 /// A resource identifier for a localization resource.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone)]
 pub struct ResourceId {
     /// The resource identifier.
     pub value: String,
@@ -117,6 +117,12 @@ impl Eq for ResourceId {}
 impl PartialEq for ResourceId {
     fn eq(&self, other: &Self) -> bool {
         self.value.eq(&other.value)
+    }
+}
+
+impl std::hash::Hash for ResourceId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
     }
 }
 

--- a/fluent-fallback/tests/localization_test.rs
+++ b/fluent-fallback/tests/localization_test.rs
@@ -212,7 +212,7 @@ fn localization_format_value_missing_errors() {
     let res_mgr = ResourceManager;
     let mut errors = vec![];
 
-    let loc = Localization::with_env(resource_ids, true, locales.clone(), res_mgr);
+    let loc = Localization::with_env(resource_ids, true, locales, res_mgr);
     let bundles = loc.bundles();
 
     let _ = bundles
@@ -268,7 +268,7 @@ fn localization_format_value_sync_missing_errors() {
     let res_mgr = ResourceManager;
     let mut errors = vec![];
 
-    let loc = Localization::with_env(resource_ids, true, locales.clone(), res_mgr);
+    let loc = Localization::with_env(resource_ids, true, locales, res_mgr);
     let bundles = loc.bundles();
 
     let _ = bundles
@@ -324,7 +324,7 @@ fn localization_format_values_sync_missing_errors() {
     let res_mgr = ResourceManager;
     let mut errors = vec![];
 
-    let loc = Localization::with_env(resource_ids, true, locales.clone(), res_mgr);
+    let loc = Localization::with_env(resource_ids, true, locales, res_mgr);
     let bundles = loc.bundles();
 
     let _ = bundles
@@ -395,7 +395,7 @@ fn localization_format_messages_sync_missing_errors() {
     let res_mgr = ResourceManager;
     let mut errors = vec![];
 
-    let loc = Localization::with_env(resource_ids, true, locales.clone(), res_mgr);
+    let loc = Localization::with_env(resource_ids, true, locales, res_mgr);
     let bundles = loc.bundles();
 
     let _ = bundles

--- a/fluent-resmgr/examples/simple-resmgr.rs
+++ b/fluent-resmgr/examples/simple-resmgr.rs
@@ -53,7 +53,7 @@ fn get_available_locales() -> Result<Vec<LanguageIdentifier>, io::Error> {
             }
         }
     }
-    return Ok(locales);
+    Ok(locales)
 }
 
 fn main() {
@@ -74,7 +74,7 @@ fn main() {
     //    take the second argument as a comma-separated
     //    list of requested locales.
     let requested: Vec<LanguageIdentifier> = args.get(2).map_or(vec![], |arg| {
-        arg.split(",")
+        arg.split(',')
             .map(|s| s.parse().expect("Parsing locale failed."))
             .collect()
     });
@@ -99,7 +99,7 @@ fn main() {
     match args.get(1) {
         Some(input) => {
             // 6.1. Cast it to a number.
-            match isize::from_str(&input) {
+            match isize::from_str(input) {
                 Ok(i) => {
                     // 6.2. Construct a map of arguments
                     //      to format the message.
@@ -110,7 +110,7 @@ fn main() {
                     let mut errors = vec![];
                     let msg = bundle.get_message("response-msg").expect("Message exists");
                     let pattern = msg.value().expect("Message has a value");
-                    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+                    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
                     println!("{}", value);
                 }
                 Err(err) => {
@@ -122,7 +122,7 @@ fn main() {
                         .get_message("input-parse-error-msg")
                         .expect("Message exists");
                     let pattern = msg.value().expect("Message has a value");
-                    let value = bundle.format_pattern(&pattern, Some(&args), &mut errors);
+                    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
                     println!("{}", value);
                 }
             }
@@ -133,7 +133,7 @@ fn main() {
                 .get_message("missing-arg-error")
                 .expect("Message exists");
             let pattern = msg.value().expect("Message has a value");
-            let value = bundle.format_pattern(&pattern, None, &mut errors);
+            let value = bundle.format_pattern(pattern, None, &mut errors);
             println!("{}", value);
         }
     }

--- a/fluent-resmgr/tests/localization_test.rs
+++ b/fluent-resmgr/tests/localization_test.rs
@@ -41,6 +41,6 @@ fn resmgr_get_bundle() {
     let mut errors = vec![];
     let msg = bundle.get_message("hello-world").expect("Message exists");
     let pattern = msg.value().expect("Message has a value");
-    let value = bundle.format_pattern(&pattern, None, &mut errors);
+    let value = bundle.format_pattern(pattern, None, &mut errors);
     assert_eq!(value, "Hello World");
 }

--- a/fluent-syntax/benches/parser.rs
+++ b/fluent-syntax/benches/parser.rs
@@ -35,7 +35,7 @@ fn get_ctxs(tests: &[&'static str]) -> HashMap<&'static str, Vec<String>> {
             .collect::<Vec<_>>();
         ftl_strings.insert(*test, strings);
     }
-    return ftl_strings;
+    ftl_strings
 }
 
 fn parse_bench(c: &mut Criterion) {

--- a/fluent-syntax/src/ast/helper.rs
+++ b/fluent-syntax/src/ast/helper.rs
@@ -5,7 +5,7 @@ use super::Comment;
 // This is a helper struct used to properly deserialize referential
 // JSON comments which are single continous String, into a vec of
 // content slices.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum CommentDef<S> {
@@ -13,7 +13,7 @@ pub enum CommentDef<S> {
     Multi { content: Vec<S> },
 }
 
-impl<'s, S> From<CommentDef<S>> for Comment<S> {
+impl<S> From<CommentDef<S>> for Comment<S> {
     fn from(input: CommentDef<S>) -> Self {
         match input {
             CommentDef::Single { content } => Self {

--- a/fluent-syntax/src/ast/mod.rs
+++ b/fluent-syntax/src/ast/mod.rs
@@ -584,7 +584,7 @@ pub struct Attribute<S> {
 ///     }
 /// );
 /// ```
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Identifier<S> {
     pub name: S,
@@ -752,7 +752,7 @@ pub struct Variant<S> {
 ///     }
 /// );
 /// ```
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum VariantKey<S> {
@@ -798,7 +798,7 @@ pub enum VariantKey<S> {
 ///     }
 /// );
 /// ```
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "helper::CommentDef<S>"))]
 pub struct Comment<S> {

--- a/fluent-syntax/src/parser/errors.rs
+++ b/fluent-syntax/src/parser/errors.rs
@@ -92,7 +92,7 @@ use thiserror::Error;
 /// The information contained in the `ParserError` should allow the tooling
 /// to display rich contextual annotations of the error slice, using
 /// crates such as `annotate-snippers`.
-#[derive(Error, Debug, PartialEq, Clone)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 #[error("{}", self.kind)]
 pub struct ParserError {
     /// Precise location of where the parser encountered the error.
@@ -122,7 +122,7 @@ macro_rules! error {
 }
 
 /// Kind of an error associated with the [`ParserError`].
-#[derive(Error, Debug, PartialEq, Clone)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum ErrorKind {
     #[error("Expected a token starting with \"{0}\"")]
     ExpectedToken(char),

--- a/intl-memoizer/examples/numberformat.rs
+++ b/intl-memoizer/examples/numberformat.rs
@@ -64,7 +64,7 @@ fn main() {
 
     {
         // Here, we will construct a new lang memoizer
-        let lang_memoizer = memoizer.get_for_lang(lang.clone());
+        let lang_memoizer = memoizer.get_for_lang(lang);
         let options = NumberFormatOptions {
             minimum_fraction_digits: 3,
             maximum_fraction_digits: 5,

--- a/intl-memoizer/examples/pluralrules.rs
+++ b/intl-memoizer/examples/pluralrules.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut memoizer = IntlMemoizer::default();
 
     let lang: LanguageIdentifier = "en".parse().unwrap();
-    let lang_memoizer = memoizer.get_for_lang(lang.clone());
+    let lang_memoizer = memoizer.get_for_lang(lang);
     let result = lang_memoizer
         .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |pr| pr.0.select(5))
         .unwrap();

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -399,7 +399,7 @@ mod tests {
         }
 
         {
-            let en_memoizer = memoizer.get_for_lang(lang.clone());
+            let en_memoizer = memoizer.get_for_lang(lang);
 
             let result = en_memoizer
                 .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |cb| cb.0.select(5))


### PR DESCRIPTION
Fixing up clippy warnings/errors before working on #287 

For reference:
`PartialEq, Eq`: https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
Derived `Hash` with `impl PartialEq`: https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq