### PR TITLE
Start using workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,20 @@ members = [
 exclude = [
     "fluent-cli",
 ]
+
+[workspace.dependencies]
+criterion = "0.3"
+fluent-langneg = "0.13"
+futures = "0.3"
+iai = "0.1"
+intl_pluralrules = "7.0.1"
+rustc-hash = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+tokio = "1.0"
+unic-langid = "0.9"
+
+fluent-bundle = { version = "0.15.2", path = "fluent-bundle" }
+fluent-fallback = { version = "0.7.0", path = "fluent-fallback" }
+fluent-syntax = { version = "0.11", path = "fluent-syntax" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3"
 iai = "0.1"
 intl_pluralrules = "7.0.1"
 rustc-hash = "1"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = "1.0"
@@ -29,4 +29,5 @@ unic-langid = "0.9"
 
 fluent-bundle = { version = "0.15.2", path = "fluent-bundle" }
 fluent-fallback = { version = "0.7.0", path = "fluent-fallback" }
+fluent-pseudo = { version = "0.3", path = "fluent-pseudo" }
 fluent-syntax = { version = "0.11", path = "fluent-syntax" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0"
 tokio = "1.0"
 unic-langid = "0.9"
 
-fluent-bundle = { version = "0.15.2", path = "fluent-bundle" }
-fluent-fallback = { version = "0.7.0", path = "fluent-fallback" }
-fluent-pseudo = { version = "0.3", path = "fluent-pseudo" }
-fluent-syntax = { version = "0.11", path = "fluent-syntax" }
+fluent-bundle = { path = "fluent-bundle" }
+fluent-fallback = { path = "fluent-fallback" }
+fluent-pseudo = { path = "fluent-pseudo" }
+fluent-syntax = { path = "fluent-syntax" }

--- a/docs/local-testing-firefox.md
+++ b/docs/local-testing-firefox.md
@@ -1,0 +1,54 @@
+# Local testing against the Firefox codebase
+
+Testing `fluent-rs` locally against a local copy of the Firefox codebase can be done with the following steps.
+
+## 1. Clone Firefox locally
+
+Bootstrap a copy of the Firefox source code without the Artifact Builds (it is needed to be able to modify the Rust dependencies).
+
+See the [Firefox Contributors’ Quick Reference](https://firefox-source-docs.mozilla.org/contributing/contribution_quickref.html) for more information on how to achieve that on your operating system.
+
+## 2. Delete the `fluent-rs` vendored packages
+
+Remove the following packages from the `mozilla-unified/third_party/rust` directory:
+
+- fluent
+- fluent-bundle
+- fluent-fallback
+- fluent-pseudo 
+- fluent-syntax 
+- fluent-testing
+- intl-memoizer
+
+## 3. Bump version numbers
+
+To avoid the `Some non-crates.io-fetched packages match published crates.io versions` error while checking the `fluent-rs` dependencies in the Firefox codebase, we must first bump the version of all the `fluent-rs` packages.
+
+To update a package, use the `cargo-release` tool. It can be installed with `cargo install cargo-release`.
+
+Run the following command in the `fluent-rs` directory to bump the version of all its packages:
+
+```
+cargo release version patch -p fluent -p fluent-bundle -p fluent-fallback -p fluent-pseudo -p fluent-syntax -p fluent-testing -p intl-memoizer --execute`
+```
+
+## 4. Upgrade dependencies
+
+Now we need to upgrade all the dependencies to `fluent-rs` in the Firefox codebase to match our local copy.
+
+- [Search for all references](https://searchfox.org/mozilla-central/search?q=%5E%28fluent%28-%5Cw%2B%29%3F%7Cintl-memoizer%29+%3D+%22.*%22&path=&case=false&regexp=true)
+- Update all the references to our local packages by using `{ path = "..." }` in the `Cargo.toml` file of the impacted packages.
+
+### Exemple
+
+If both `fluent-rs` and `mozilla_unified` directories are on the same root directory, you can update the `fluent-fallback` entry from `fluent-fallback = "0.7.0"` to `fluent-fallback = { path = "../../../../../fluent-rs/fluent-fallback" }` in the `mozilla-unified/intl/l10n/rust/l10nregistry-ffi/Cargo.toml` file.
+
+## 5. Check the local `fluent-rs` dependencies
+
+It is done by running `./mach vendor rust` at the root of the `mozilla-unified` directory. If the `./mach vendor rust` command runs without any problems, you're good to go!
+
+### Vetting a dependency
+
+If you see an error similar to `intel-memoizer type-map = "0.5" must be vetted (current vetted version at 0.4) =`, it means that the current vetted version of the `type-map` package is `0.4` but we're using the `0.5` version in `fluent-rs`.
+
+It can be fixed in the `supply-chain/config.toml` file by bumping the version in the `[[exemptions.type-map]]` to `0.5`.

--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -31,7 +31,7 @@ fluent-syntax.workspace = true
 intl_pluralrules.workspace = true
 rustc-hash.workspace = true
 unic-langid.workspace = true
-intl-memoizer = { version = "0.5", path = "../intl-memoizer" }
+intl-memoizer = { path = "../intl-memoizer" }
 self_cell = "0.10"
 smallvec = "1"
 

--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -26,22 +26,22 @@ include = [
 ]
 
 [dependencies]
-fluent-langneg = "0.13"
-fluent-syntax = { version = "0.11", path = "../fluent-syntax" }
-intl_pluralrules = "7.0.1"
+fluent-langneg.workspace = true
+fluent-syntax.workspace = true
+intl_pluralrules.workspace = true
+rustc-hash.workspace = true
+unic-langid.workspace = true
 intl-memoizer = { version = "0.5", path = "../intl-memoizer" }
-rustc-hash = "1"
 self_cell = "0.10"
 smallvec = "1"
-unic-langid = "0.9"
 
 [dev-dependencies]
-criterion = "0.3"
-iai = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8"
+criterion.workspace = true
+iai.workspace = true
+serde.workspace = true
+unic-langid = { workspace = true, features = ["macros"] }
 rand = "0.8"
-unic-langid = { version = "0.9", features = ["macros"] }
+serde_yaml = "0.8"
 
 [features]
 default = []

--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -38,7 +38,7 @@ smallvec = "1"
 [dev-dependencies]
 criterion.workspace = true
 iai.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"]}
 unic-langid = { workspace = true, features = ["macros"] }
 rand = "0.8"
 serde_yaml = "0.8"

--- a/fluent-cli/Cargo.toml
+++ b/fluent-cli/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/main.rs"
 [dependencies]
 fluent-bundle.workspace = true
 fluent-syntax.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"]}
 serde_json.workspace = true
 annotate-snippets = { version = "0.6", features = ["color"] }
 clap = "2.33"

--- a/fluent-cli/Cargo.toml
+++ b/fluent-cli/Cargo.toml
@@ -26,9 +26,9 @@ name = "parser-cli"
 path = "src/main.rs"
 
 [dependencies]
-annotate-snippets = {version = "0.6", features = ["color"]}
+fluent-bundle.workspace = true
+fluent-syntax.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+annotate-snippets = { version = "0.6", features = ["color"] }
 clap = "2.33"
-fluent-syntax = "0.11"
-fluent-bundle = "0.15"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"

--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -18,16 +18,16 @@ keywords = ["localization", "l10n", "i18n", "intl", "internationalization"]
 categories = ["localization", "internationalization"]
 
 [dependencies]
-chunky-vec = "0.1"
-fluent-bundle = { version = "0.15.2", path = "../fluent-bundle" }
-futures = "0.3"
+fluent-bundle.workspace = true
+futures.workspace = true
+rustc-hash.workspace = true
+unic-langid.workspace = true
 async-trait = "0.1"
-unic-langid = { version = "0.9" }
+chunky-vec = "0.1"
 once_cell = "1.9"
-rustc-hash = "1"
 
 [dev-dependencies]
-fluent-langneg = "0.13"
-unic-langid = { version = "0.9", features = ["macros"] }
+fluent-langneg.workspace = true
+unic-langid = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 fluent-resmgr = { path = "../fluent-resmgr" }
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }

--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -17,14 +17,14 @@ keywords = ["localization", "l10n", "i18n", "intl", "internationalization"]
 categories = ["localization", "internationalization"]
 
 [dependencies]
-fluent-bundle = { version = "0.15.2", path = "../fluent-bundle" }
-fluent-fallback = { version = "0.7.0", path = "../fluent-fallback" }
-unic-langid = "0.9"
+fluent-bundle.workspace = true
+fluent-fallback.workspace = true
+futures.workspace = true
+rustc-hash.workspace = true
+thiserror.workspace = true
+unic-langid.workspace = true
 elsa = "1.5"
-futures = "0.3"
-rustc-hash = "1"
-thiserror = "1.0"
 
 [dev-dependencies]
-unic-langid = { version = "0.9", features = ["macros"]}
-fluent-langneg = "0.13"
+fluent-langneg.workspace = true
+unic-langid = { workspace = true, features = ["macros"] }

--- a/fluent-syntax/Cargo.toml
+++ b/fluent-syntax/Cargo.toml
@@ -25,14 +25,14 @@ include = [
 ]
 
 [dependencies]
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
 iai.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 glob = "0.3"
 

--- a/fluent-syntax/Cargo.toml
+++ b/fluent-syntax/Cargo.toml
@@ -25,16 +25,16 @@ include = [
 ]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
-thiserror = "1.0"
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+thiserror.workspace = true
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+criterion.workspace = true
+iai.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 glob = "0.3"
-criterion = "0.3"
-iai = "0.1"
 
 [features]
 default = []

--- a/fluent-testing/Cargo.toml
+++ b/fluent-testing/Cargo.toml
@@ -25,9 +25,9 @@ include = [
 ]
 
 [dependencies]
-fluent-bundle = { version = "0.15.2", path = "../fluent-bundle" }
-fluent-fallback = { version = "0.7.0", path = "../fluent-fallback" }
-tokio = { version = "1.0", optional = true, features = ["fs", "rt-multi-thread", "macros", "io-util"] }
+fluent-bundle.workspace = true
+fluent-fallback.workspace = true
+tokio = { workspace = true, optional = true, features = ["fs", "rt-multi-thread", "macros", "io-util"] }
 
 [features]
 default = ["sync"]

--- a/fluent/Cargo.toml
+++ b/fluent/Cargo.toml
@@ -26,6 +26,6 @@ include = [
 ]
 
 [dependencies]
-fluent-bundle = { version = "0.15", path = "../fluent-bundle" }
-unic-langid = "0.9"
+fluent-bundle.workspace = true
+unic-langid.workspace = true
 fluent-pseudo = { version = "0.3", optional = true }

--- a/fluent/Cargo.toml
+++ b/fluent/Cargo.toml
@@ -27,5 +27,5 @@ include = [
 
 [dependencies]
 fluent-bundle.workspace = true
+fluent-pseudo = { workspace = true, optional = true }
 unic-langid.workspace = true
-fluent-pseudo = { version = "0.3", optional = true }

--- a/intl-memoizer/Cargo.toml
+++ b/intl-memoizer/Cargo.toml
@@ -26,9 +26,9 @@ include = [
 ]
 
 [dependencies]
+unic-langid.workspace = true
 type-map = "0.5"
-unic-langid = "0.9"
 
 [dev-dependencies]
-intl_pluralrules = "7.0.1"
-fluent-langneg = "0.13"
+intl_pluralrules.workspace = true
+fluent-langneg.workspace = true


### PR DESCRIPTION
As discussed in https://github.com/projectfluent/fluent-rs/pull/282#discussion_r1035019918 here's a separate PR to test the ability to use workspace dependencies that were introduced in Rust 1.64.

From what I see in the [Firefox Rust update policy](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html) it should be ok as this is the Rust version used in the latest stable release of Firefox (lucky us haha).

![Screenshot 2022-11-30 at 12 46 55](https://user-images.githubusercontent.com/383297/204788369-e0045339-0c4d-4ef0-a9fd-f7c351090280.png)
