### PR TITLE
Add FluentValue.into_string to prevent String clone

### DIFF
--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -494,7 +494,7 @@ impl<R, M> FluentBundle<R, M> {
     {
         let mut scope = Scope::new(self, args, Some(errors));
         let value = pattern.resolve(&mut scope);
-        value.as_string(&scope)
+        value.into_string(&scope)
     }
 
     /// Makes the provided rust function available to messages with the name `id`. See

--- a/fluent-bundle/src/resolver/inline_expression.rs
+++ b/fluent-bundle/src/resolver/inline_expression.rs
@@ -93,7 +93,7 @@ impl<'bundle> WriteValue<'bundle> for ast::InlineExpression<&'bundle str> {
                     if let FluentValue::Error = result {
                         self.write_error(w)
                     } else {
-                        w.write_str(&result.as_string(scope))
+                        w.write_str(&result.into_string(scope))
                     }
                 } else {
                     scope.write_ref_error(w, self)

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -235,6 +235,9 @@ impl<'source> FluentValue<'source> {
     }
 
     /// Converts the [`FluentValue`] to a string.
+    ///
+    /// Clones inner values when owned, borrowed data is not cloned.
+    /// Prefer using [`FluentValue::into_string()`] when possible.
     pub fn as_string<R: Borrow<FluentResource>, M>(&self, scope: &Scope<R, M>) -> Cow<'source, str>
     where
         M: MemoizerKind,
@@ -254,6 +257,9 @@ impl<'source> FluentValue<'source> {
     }
 
     /// Converts the [`FluentValue`] to a string.
+    ///
+    /// Takes self by-value to be able to skip expensive clones.
+    /// Prefer this method over [`FluentValue::as_string()`] when possible.
     pub fn into_string<R: Borrow<FluentResource>, M>(self, scope: &Scope<R, M>) -> Cow<'source, str>
     where
         M: MemoizerKind,

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -253,6 +253,25 @@ impl<'source> FluentValue<'source> {
         }
     }
 
+    /// Converts the [`FluentValue`] to a string.
+    pub fn into_string<R: Borrow<FluentResource>, M>(self, scope: &Scope<R, M>) -> Cow<'source, str>
+    where
+        M: MemoizerKind,
+    {
+        if let Some(formatter) = &scope.bundle.formatter {
+            if let Some(val) = formatter(&self, &scope.bundle.intls) {
+                return val.into();
+            }
+        }
+        match self {
+            FluentValue::String(s) => s,
+            FluentValue::Number(n) => n.as_string(),
+            FluentValue::Custom(s) => scope.bundle.intls.stringify_value(s.as_ref()),
+            FluentValue::Error => "".into(),
+            FluentValue::None => "".into(),
+        }
+    }
+
     pub fn into_owned<'a>(&self) -> FluentValue<'a> {
         match self {
             FluentValue::String(str) => FluentValue::String(Cow::from(str.to_string())),


### PR DESCRIPTION
This method works the same as FluentValue.as_string, but takes self by-value to prevent cloning Strings. All usages of as_string have been replaced by into_string (FluentValues are always dropped right after converting to string).
