### PR TITLE
ICU4x number formatting

### DIFF
--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -26,8 +26,12 @@ include = [
 ]
 
 [dependencies]
+fixed_decimal = { version = "0.5.1", features = ["ryu"] }
 fluent-langneg.workspace = true
 fluent-syntax.workspace = true
+icu_decimal = "1"
+icu_locid = "1"
+icu_provider = { version = "1", features = ["sync"] }
 intl_pluralrules.workspace = true
 rustc-hash.workspace = true
 unic-langid.workspace = true

--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -42,6 +42,7 @@ smallvec = "1"
 [dev-dependencies]
 criterion.workspace = true
 iai.workspace = true
+icu_testdata = "1"
 serde = { workspace = true, features = ["derive"]}
 unic-langid = { workspace = true, features = ["macros"] }
 rand = "0.8"

--- a/fluent-bundle/examples/custom_type.rs
+++ b/fluent-bundle/examples/custom_type.rs
@@ -107,7 +107,7 @@ impl FluentType for DateTime {
     }
     fn as_string(&self, intls: &intl_memoizer::IntlLangMemoizer) -> std::borrow::Cow<'static, str> {
         intls
-            .with_try_get::<DateTimeFormatter, _, _>((self.options.clone(),), |dtf| {
+            .with_try_get::<DateTimeFormatter, _, _>((self.options.clone(),), &(), |dtf| {
                 dtf.format(self.epoch).into()
             })
             .expect("Failed to format a date.")
@@ -143,7 +143,13 @@ impl DateTimeFormatter {
 impl Memoizable for DateTimeFormatter {
     type Args = (DateTimeOptions,);
     type Error = ();
-    fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+    type DataProvider = ();
+
+    fn construct(
+        lang: LanguageIdentifier,
+        args: Self::Args,
+        _: &Self::DataProvider,
+    ) -> Result<Self, Self::Error> {
         Self::new(lang, args.0)
     }
 }

--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -551,6 +551,10 @@ impl<R, M> FluentBundle<R, M> {
             }),
         }
     }
+
+    pub fn set_icu_data_provider(&mut self, provider: IcuDataProvider) {
+        self.icu_data_provider = Some(provider);
+    }
 }
 
 impl<R> Default for FluentBundle<R, IntlLangMemoizer> {

--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -4,6 +4,7 @@
 //! internationalization formatters, functions, scopeironmental variables and are expected to be used
 //! together.
 
+use icu_provider::AnyProvider;
 use rustc_hash::FxHashMap;
 use std::borrow::Borrow;
 use std::borrow::Cow;
@@ -24,6 +25,8 @@ use crate::message::FluentMessage;
 use crate::resolver::{ResolveValue, Scope, WriteValue};
 use crate::resource::FluentResource;
 use crate::types::FluentValue;
+
+pub type IcuDataProvider = Box<dyn AnyProvider>;
 
 /// A collection of localization messages for a single locale, which are meant
 /// to be used together in a single view, widget or any other UI abstraction.
@@ -141,6 +144,7 @@ pub struct FluentBundle<R, M> {
     pub(crate) use_isolating: bool,
     pub(crate) transform: Option<fn(&str) -> Cow<str>>,
     pub(crate) formatter: Option<fn(&FluentValue, &M) -> Option<String>>,
+    pub(crate) icu_data_provider: Option<IcuDataProvider>,
 }
 
 impl<R, M> FluentBundle<R, M> {
@@ -586,6 +590,7 @@ impl<R> FluentBundle<R, IntlLangMemoizer> {
             use_isolating: true,
             transform: None,
             formatter: None,
+            icu_data_provider: None,
         }
     }
 }

--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -598,14 +598,19 @@ impl crate::memoizer::MemoizerKind for IntlLangMemoizer {
         Self::new(lang)
     }
 
-    fn with_try_get_threadsafe<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
+    fn with_try_get_threadsafe<I, R, U>(
+        &self,
+        args: I::Args,
+        data_provider: &I::DataProvider,
+        cb: U,
+    ) -> Result<R, I::Error>
     where
         Self: Sized,
         I: intl_memoizer::Memoizable + Send + Sync + 'static,
         I::Args: Send + Sync + 'static,
         U: FnOnce(&I) -> R,
     {
-        self.with_try_get(args, cb)
+        self.with_try_get(args, data_provider, cb)
     }
 
     fn stringify_value(

--- a/fluent-bundle/src/concurrent.rs
+++ b/fluent-bundle/src/concurrent.rs
@@ -31,6 +31,7 @@ impl<R> FluentBundle<R, IntlLangMemoizer> {
             use_isolating: true,
             transform: None,
             formatter: None,
+            icu_data_provider: None,
         }
     }
 }

--- a/fluent-bundle/src/concurrent.rs
+++ b/fluent-bundle/src/concurrent.rs
@@ -43,14 +43,19 @@ impl MemoizerKind for IntlLangMemoizer {
         Self::new(lang)
     }
 
-    fn with_try_get_threadsafe<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
+    fn with_try_get_threadsafe<I, R, U>(
+        &self,
+        args: I::Args,
+        data_provider: &I::DataProvider,
+        cb: U,
+    ) -> Result<R, I::Error>
     where
         Self: Sized,
         I: Memoizable + Send + Sync + 'static,
         I::Args: Send + Sync + 'static,
         U: FnOnce(&I) -> R,
     {
-        self.with_try_get(args, cb)
+        self.with_try_get(args, data_provider, cb)
     }
 
     fn stringify_value(&self, value: &dyn FluentType) -> std::borrow::Cow<'static, str> {

--- a/fluent-bundle/src/memoizer.rs
+++ b/fluent-bundle/src/memoizer.rs
@@ -18,7 +18,12 @@ pub trait MemoizerKind: 'static {
     ///
     /// `U` - The callback that accepts the instance of the intl formatter, and generates
     ///       some kind of results `R`.
-    fn with_try_get_threadsafe<I, R, U>(&self, args: I::Args, callback: U) -> Result<R, I::Error>
+    fn with_try_get_threadsafe<I, R, U>(
+        &self,
+        args: I::Args,
+        data_provider: &I::DataProvider,
+        callback: U,
+    ) -> Result<R, I::Error>
     where
         Self: Sized,
         I: Memoizable + Send + Sync + 'static,

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -205,6 +205,7 @@ impl<'source> FluentValue<'source> {
                     .intls
                     .with_try_get_threadsafe::<PluralRules, _, _>(
                         (PluralRuleType::CARDINAL,),
+                        &(),
                         |pr| pr.0.select(b) == Ok(cat),
                     )
                     .unwrap()

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -228,7 +228,7 @@ impl<'source> FluentValue<'source> {
         }
         match self {
             FluentValue::String(s) => w.write_str(s),
-            FluentValue::Number(n) => w.write_str(&n.as_string()),
+            FluentValue::Number(n) => w.write_str(&n.as_string(scope.bundle)),
             FluentValue::Custom(s) => w.write_str(&scope.bundle.intls.stringify_value(&**s)),
             FluentValue::Error => Ok(()),
             FluentValue::None => Ok(()),
@@ -247,7 +247,7 @@ impl<'source> FluentValue<'source> {
         }
         match self {
             FluentValue::String(s) => s.clone(),
-            FluentValue::Number(n) => n.as_string(),
+            FluentValue::Number(n) => n.as_string(scope.bundle),
             FluentValue::Custom(s) => scope.bundle.intls.stringify_value(&**s),
             FluentValue::Error => "".into(),
             FluentValue::None => "".into(),

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -3,9 +3,19 @@ use std::convert::TryInto;
 use std::default::Default;
 use std::str::FromStr;
 
+use fixed_decimal::{DoublePrecision, FixedDecimal};
+use icu_decimal::options::{FixedDecimalFormatterOptions, GroupingStrategy};
+use icu_decimal::provider::DecimalSymbolsV1Marker;
+use icu_decimal::{DecimalError, FixedDecimalFormatter};
+use icu_locid::{LanguageIdentifier as IcuLanguageIdentifier, ParserError};
+use icu_provider::prelude::*;
+use intl_memoizer::Memoizable;
 use intl_pluralrules::operands::PluralOperands;
+use unic_langid::LanguageIdentifier;
 
 use crate::args::FluentArgs;
+use crate::bundle::{FluentBundle, IcuDataProvider};
+use crate::memoizer::MemoizerKind;
 use crate::types::FluentValue;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -133,22 +143,38 @@ impl FluentNumber {
         Self { value, options }
     }
 
-    pub fn as_string(&self) -> Cow<'static, str> {
-        let mut val = self.value.to_string();
-        if let Some(minfd) = self.options.minimum_fraction_digits {
-            if let Some(pos) = val.find('.') {
-                let frac_num = val.len() - pos - 1;
-                let missing = if frac_num > minfd {
-                    0
-                } else {
-                    minfd - frac_num
-                };
-                val = format!("{}{}", val, "0".repeat(missing));
-            } else {
-                val = format!("{}.{}", val, "0".repeat(minfd));
-            }
+    pub fn as_string<R, M: MemoizerKind>(&self, bundle: &FluentBundle<R, M>) -> Cow<'static, str> {
+        let fixed_decimal = self.as_fixed_decimal();
+        let options = FormatterOptions {
+            use_grouping: self.options.use_grouping,
+        };
+        if let Some(data_provider) = &bundle.icu_data_provider {
+            let formatted = bundle
+                .intls
+                .with_try_get_threadsafe::<NumberFormatter, _, _>(
+                    (options,),
+                    data_provider,
+                    |formatter| formatter.0.format_to_string(&fixed_decimal),
+                )
+                .unwrap();
+            return formatted.into();
         }
-        val.into()
+
+        fixed_decimal.to_string().into()
+    }
+
+    fn as_fixed_decimal(&self) -> FixedDecimal {
+        let mut fixed_decimal =
+            FixedDecimal::try_from_f64(self.value, DoublePrecision::Floating).unwrap();
+
+        if let Some(minfd) = self.options.minimum_fraction_digits {
+            fixed_decimal.pad_end(-(minfd as i16));
+        }
+        fixed_decimal
+    }
+
+    pub fn as_string_basic(&self) -> String {
+        self.as_fixed_decimal().to_string()
     }
 }
 
@@ -238,8 +264,58 @@ from_num!(i8 i16 i32 i64 i128 isize);
 from_num!(u8 u16 u32 u64 u128 usize);
 from_num!(f32 f64);
 
+pub type NumberFormatProvider = Box<dyn DataProvider<DecimalSymbolsV1Marker>>;
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Hash)]
+struct FormatterOptions {
+    use_grouping: bool,
+}
+
+struct NumberFormatter(FixedDecimalFormatter);
+
+#[derive(Debug)]
+enum NumberFormatterError {
+    ParserError(ParserError),
+    DecimalError(DecimalError),
+}
+
+impl Memoizable for NumberFormatter {
+    type Args = (FormatterOptions,);
+    type Error = NumberFormatterError;
+    type DataProvider = IcuDataProvider;
+
+    fn construct(
+        lang: LanguageIdentifier,
+        args: Self::Args,
+        data_provider: &Self::DataProvider,
+    ) -> Result<Self, Self::Error> {
+        let locale = to_icu_lang_id(lang).map_err(NumberFormatterError::ParserError)?;
+
+        let mut options: FixedDecimalFormatterOptions = Default::default();
+        options.grouping_strategy = match args.0.use_grouping {
+            true => GroupingStrategy::Always,
+            false => GroupingStrategy::Auto,
+        };
+
+        let inner = FixedDecimalFormatter::try_new_with_any_provider(
+            data_provider,
+            &locale.into(),
+            options,
+        )
+        .map_err(NumberFormatterError::DecimalError)?;
+        Ok(NumberFormatter(inner))
+    }
+}
+
+fn to_icu_lang_id(lang: LanguageIdentifier) -> Result<IcuLanguageIdentifier, ParserError> {
+    return IcuLanguageIdentifier::try_from_locale_bytes(lang.to_string().as_bytes());
+}
+
 #[cfg(test)]
 mod tests {
+    use super::to_icu_lang_id;
+    use unic_langid::langid;
+
     use crate::types::FluentValue;
 
     #[test]
@@ -248,5 +324,17 @@ mod tests {
         let y = &x;
         let z: FluentValue = y.into();
         assert_eq!(z, FluentValue::try_number(1));
+    }
+
+    #[test]
+    fn lang_to_icu() {
+        assert_eq!(
+            to_icu_lang_id(langid!("en-US")).unwrap(),
+            icu_locid::langid!("en-US")
+        );
+        assert_eq!(
+            to_icu_lang_id(langid!("pl")).unwrap(),
+            icu_locid::langid!("pl")
+        );
     }
 }

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -66,33 +66,31 @@ impl From<&str> for FluentNumberCurrencyDisplayStyle {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum FluentNumberUseGrouping {
+    Auto,
+    False,
+    Always,
+    Min2,
+}
+
+impl Default for FluentNumberUseGrouping {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct FluentNumberOptions {
     pub style: FluentNumberStyle,
     pub currency: Option<String>,
     pub currency_display: FluentNumberCurrencyDisplayStyle,
-    pub use_grouping: bool,
+    pub use_grouping: FluentNumberUseGrouping,
     pub minimum_integer_digits: Option<usize>,
     pub minimum_fraction_digits: Option<usize>,
     pub maximum_fraction_digits: Option<usize>,
     pub minimum_significant_digits: Option<usize>,
     pub maximum_significant_digits: Option<usize>,
-}
-
-impl Default for FluentNumberOptions {
-    fn default() -> Self {
-        Self {
-            style: Default::default(),
-            currency: None,
-            currency_display: Default::default(),
-            use_grouping: true,
-            minimum_integer_digits: None,
-            minimum_fraction_digits: None,
-            maximum_fraction_digits: None,
-            minimum_significant_digits: None,
-            maximum_significant_digits: None,
-        }
-    }
 }
 
 impl FluentNumberOptions {
@@ -109,7 +107,12 @@ impl FluentNumberOptions {
                     self.currency_display = n.as_ref().into();
                 }
                 ("useGrouping", FluentValue::String(n)) => {
-                    self.use_grouping = n != "false";
+                    self.use_grouping = match n.as_ref() {
+                        "false" => FluentNumberUseGrouping::False,
+                        "always" => FluentNumberUseGrouping::Always,
+                        "min2" => FluentNumberUseGrouping::Min2,
+                        _ => FluentNumberUseGrouping::Auto,
+                    }
                 }
                 ("minimumIntegerDigits", FluentValue::Number(n)) => {
                     self.minimum_integer_digits = Some(n.into());
@@ -266,9 +269,9 @@ from_num!(f32 f64);
 
 pub type NumberFormatProvider = Box<dyn DataProvider<DecimalSymbolsV1Marker>>;
 
-#[derive(Debug, Eq, PartialEq, Clone, Default, Hash)]
+#[derive(Clone, Hash, PartialEq, Eq)]
 struct FormatterOptions {
-    use_grouping: bool,
+    use_grouping: FluentNumberUseGrouping,
 }
 
 struct NumberFormatter(FixedDecimalFormatter);
@@ -293,8 +296,10 @@ impl Memoizable for NumberFormatter {
 
         let mut options: FixedDecimalFormatterOptions = Default::default();
         options.grouping_strategy = match args.0.use_grouping {
-            true => GroupingStrategy::Always,
-            false => GroupingStrategy::Auto,
+            FluentNumberUseGrouping::Auto => GroupingStrategy::Auto,
+            FluentNumberUseGrouping::False => GroupingStrategy::Never,
+            FluentNumberUseGrouping::Always => GroupingStrategy::Always,
+            FluentNumberUseGrouping::Min2 => GroupingStrategy::Min2,
         };
 
         let inner = FixedDecimalFormatter::try_new_with_any_provider(

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -167,11 +167,19 @@ impl FluentNumber {
     }
 
     fn as_fixed_decimal(&self) -> FixedDecimal {
-        let mut fixed_decimal =
-            FixedDecimal::try_from_f64(self.value, DoublePrecision::Floating).unwrap();
+        let precision = if let Some(maxsd) = self.options.maximum_significant_digits {
+            DoublePrecision::SignificantDigits(maxsd as u8)
+        } else {
+            DoublePrecision::Floating
+        };
+
+        let mut fixed_decimal = FixedDecimal::try_from_f64(self.value, precision).unwrap();
 
         if let Some(minfd) = self.options.minimum_fraction_digits {
             fixed_decimal.pad_end(-(minfd as i16));
+        }
+        if let Some(minid) = self.options.minimum_integer_digits {
+            fixed_decimal.pad_start(minid as i16);
         }
         fixed_decimal
     }

--- a/fluent-bundle/src/types/plural.rs
+++ b/fluent-bundle/src/types/plural.rs
@@ -8,7 +8,13 @@ pub struct PluralRules(pub IntlPluralRules);
 impl Memoizable for PluralRules {
     type Args = (PluralRuleType,);
     type Error = &'static str;
-    fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+    type DataProvider = ();
+
+    fn construct(
+        lang: LanguageIdentifier,
+        args: Self::Args,
+        _: &Self::DataProvider,
+    ) -> Result<Self, Self::Error> {
         let default_lang: LanguageIdentifier = "en".parse().unwrap();
         let pr_lang = negotiate_languages(
             &[lang],

--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -126,7 +126,7 @@ fn fluent_number_style() {
     let num = FluentNumber::new(0.2, FluentNumberOptions::default());
     assert_eq!(num.as_string_basic(), "0.2");
 
-    let opts = FluentNumberOptions {
+    let mut opts = FluentNumberOptions {
         minimum_fraction_digits: Some(3),
         ..Default::default()
     };
@@ -134,8 +134,26 @@ fn fluent_number_style() {
     let num = FluentNumber::new(0.2, opts.clone());
     assert_eq!(num.as_string_basic(), "0.200");
 
-    let num = FluentNumber::new(2.0, opts);
+    let num = FluentNumber::new(2.0, opts.clone());
     assert_eq!(num.as_string_basic(), "2.000");
+
+    opts.minimum_integer_digits = Some(3);
+    opts.minimum_fraction_digits = None;
+
+    let num = FluentNumber::new(2.0, opts.clone());
+    assert_eq!(num.as_string_basic(), "002");
+
+    let num = FluentNumber::new(0.2, opts.clone());
+    assert_eq!(num.as_string_basic(), "000.2");
+
+    opts.minimum_integer_digits = None;
+    opts.maximum_significant_digits = Some(4);
+
+    let num = FluentNumber::new(12345.0, opts.clone());
+    assert_eq!(num.as_string_basic(), "12340");
+
+    let num = FluentNumber::new(1.2345, opts);
+    assert_eq!(num.as_string_basic(), "1.234");
 }
 
 #[test]

--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -1,6 +1,7 @@
 use fluent_bundle::resolver::Scope;
 use fluent_bundle::types::{
-    FluentNumber, FluentNumberCurrencyDisplayStyle, FluentNumberOptions, FluentNumberStyle, FluentNumberUseGrouping,
+    FluentNumber, FluentNumberCurrencyDisplayStyle, FluentNumberOptions, FluentNumberStyle,
+    FluentNumberUseGrouping,
 };
 use fluent_bundle::FluentArgs;
 use fluent_bundle::FluentBundle;
@@ -153,4 +154,25 @@ fn fluent_number_to_operands() {
             t: 81,
         }
     );
+}
+
+#[test]
+fn fluent_number_grouping() {
+    let langid_ars = langid!("ccp");
+    let mut bundle: FluentBundle<FluentResource> = FluentBundle::new(vec![langid_ars]);
+    bundle.set_icu_data_provider(Box::new(icu_testdata::any_no_fallback()));
+
+    let mut number = FluentNumber::from(1234567890.1234567);
+
+    number.options.use_grouping = FluentNumberUseGrouping::False;
+    let no_grouping = number.as_string(&bundle);
+    assert_eq!(no_grouping, "𑄷𑄸𑄹𑄺𑄻𑄼𑄽𑄾𑄿𑄶.𑄷𑄸𑄹𑄺𑄻𑄼𑄽");
+
+    number.options.use_grouping = FluentNumberUseGrouping::Min2;
+    let long = number.as_string(&bundle);
+    assert_eq!(long, "𑄷,𑄸𑄹,𑄺𑄻,𑄼𑄽,𑄾𑄿𑄶.𑄷𑄸𑄹𑄺𑄻𑄼𑄽");
+
+    number.value = -1234.0;
+    let short = number.as_string(&bundle);
+    assert_eq!(short, "-𑄷𑄸𑄹𑄺");
 }

--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -1,6 +1,6 @@
 use fluent_bundle::resolver::Scope;
 use fluent_bundle::types::{
-    FluentNumber, FluentNumberCurrencyDisplayStyle, FluentNumberOptions, FluentNumberStyle,
+    FluentNumber, FluentNumberCurrencyDisplayStyle, FluentNumberOptions, FluentNumberStyle, FluentNumberUseGrouping,
 };
 use fluent_bundle::FluentArgs;
 use fluent_bundle::FluentBundle;
@@ -120,7 +120,7 @@ fn fluent_number_style() {
     assert_eq!(fno.style, FluentNumberStyle::Currency);
     assert_eq!(fno.currency, Some("EUR".to_string()));
     assert_eq!(fno.currency_display, FluentNumberCurrencyDisplayStyle::Code);
-    assert_eq!(fno.use_grouping, false);
+    assert_eq!(fno.use_grouping, FluentNumberUseGrouping::False);
 
     let num = FluentNumber::new(0.2, FluentNumberOptions::default());
     assert_eq!(num.as_string_basic(), "0.2");

--- a/fluent-bundle/tests/types_test.rs
+++ b/fluent-bundle/tests/types_test.rs
@@ -123,7 +123,7 @@ fn fluent_number_style() {
     assert_eq!(fno.use_grouping, false);
 
     let num = FluentNumber::new(0.2, FluentNumberOptions::default());
-    assert_eq!(num.as_string(), "0.2");
+    assert_eq!(num.as_string_basic(), "0.2");
 
     let opts = FluentNumberOptions {
         minimum_fraction_digits: Some(3),
@@ -131,10 +131,10 @@ fn fluent_number_style() {
     };
 
     let num = FluentNumber::new(0.2, opts.clone());
-    assert_eq!(num.as_string(), "0.200");
+    assert_eq!(num.as_string_basic(), "0.200");
 
     let num = FluentNumber::new(2.0, opts);
-    assert_eq!(num.as_string(), "2.000");
+    assert_eq!(num.as_string_basic(), "2.000");
 }
 
 #[test]

--- a/intl-memoizer/examples/numberformat.rs
+++ b/intl-memoizer/examples/numberformat.rs
@@ -28,7 +28,12 @@ impl NumberFormat {
 impl Memoizable for NumberFormat {
     type Args = (NumberFormatOptions,);
     type Error = ();
-    fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+    type DataProvider = ();
+    fn construct(
+        lang: LanguageIdentifier,
+        args: Self::Args,
+        _: &Self::DataProvider,
+    ) -> Result<Self, Self::Error> {
         Self::new(lang, args.0)
     }
 }
@@ -45,7 +50,7 @@ fn main() {
             maximum_fraction_digits: 5,
         };
         let result = lang_memoizer
-            .with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(2))
+            .with_try_get::<NumberFormat, _, _>((options,), &(), |nf| nf.format(2))
             .unwrap();
 
         assert_eq!(&result, "en-US: 2, MFD: 3");
@@ -57,7 +62,7 @@ fn main() {
             maximum_fraction_digits: 5,
         };
         let result = lang_memoizer
-            .with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(1))
+            .with_try_get::<NumberFormat, _, _>((options,), &(), |nf| nf.format(1))
             .unwrap();
         assert_eq!(&result, "en-US: 1, MFD: 3");
     }
@@ -70,7 +75,7 @@ fn main() {
             maximum_fraction_digits: 5,
         };
         let result = lang_memoizer
-            .with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(7))
+            .with_try_get::<NumberFormat, _, _>((options,), &(), |nf| nf.format(7))
             .unwrap();
 
         assert_eq!(&result, "en-US: 7, MFD: 3");

--- a/intl-memoizer/examples/pluralrules.rs
+++ b/intl-memoizer/examples/pluralrules.rs
@@ -13,7 +13,12 @@ impl PluralRules {
 impl Memoizable for PluralRules {
     type Args = (PluralRuleType,);
     type Error = &'static str;
-    fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+    type DataProvider = ();
+    fn construct(
+        lang: LanguageIdentifier,
+        args: Self::Args,
+        _: &Self::DataProvider,
+    ) -> Result<Self, Self::Error> {
         Self::new(lang, args.0)
     }
 }
@@ -24,7 +29,7 @@ fn main() {
     let lang: LanguageIdentifier = "en".parse().unwrap();
     let lang_memoizer = memoizer.get_for_lang(lang);
     let result = lang_memoizer
-        .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |pr| pr.0.select(5))
+        .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), &(), |pr| pr.0.select(5))
         .unwrap();
 
     assert_eq!(result, Ok(PluralCategory::OTHER));

--- a/intl-memoizer/src/concurrent.rs
+++ b/intl-memoizer/src/concurrent.rs
@@ -22,7 +22,12 @@ impl IntlLangMemoizer {
     /// Lazily initialize and run a formatter. See
     /// [`intl_memoizer::IntlLangMemoizer::with_try_get`](../struct.IntlLangMemoizer.html#method.with_try_get)
     /// for documentation.
-    pub fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
+    pub fn with_try_get<I, R, U>(
+        &self,
+        args: I::Args,
+        data_provider: &I::DataProvider,
+        cb: U,
+    ) -> Result<R, I::Error>
     where
         Self: Sized,
         I: Memoizable + Sync + Send + 'static,
@@ -37,7 +42,7 @@ impl IntlLangMemoizer {
         let e = match cache.entry(args.clone()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let val = I::construct(self.lang.clone(), args)?;
+                let val = I::construct(self.lang.clone(), args, data_provider)?;
                 entry.insert(val)
             }
         };

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -22,9 +22,16 @@ pub trait Memoizable {
     /// Type of any errors that can occur during the construction process.
     type Error;
 
+    /// Type of shared data provider
+    type DataProvider;
+
     /// Construct a formatter. This maps the [`Self::Args`] type to the actual constructor
     /// for an intl formatter.
-    fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error>
+    fn construct(
+        lang: LanguageIdentifier,
+        args: Self::Args,
+        data_provider: &Self::DataProvider,
+    ) -> Result<Self, Self::Error>
     where
         Self: std::marker::Sized;
 }
@@ -92,9 +99,12 @@ pub trait Memoizable {
 ///     /// If the construtor is fallible, than errors can be described here.
 ///     type Error = ();
 ///
+///     /// For accessing shared state to construct
+///     type DataProvider = ();
+///
 ///     /// This function wires together the `Args` and `Error` type to construct
 ///     /// the intl API. In our example, there is
-///     fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+///     fn construct(lang: LanguageIdentifier, args: Self::Args, data_provider: &Self::DataProvider) -> Result<Self, Self::Error> {
 ///         // Keep track for example purposes that this was constructed.
 ///         increment_constructs();
 ///
@@ -121,13 +131,13 @@ pub trait Memoizable {
 /// // more details.
 ///
 /// let result1 = memoizer
-///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), &(), |intl_example| {
 ///         intl_example.format(message1)
 ///     });
 ///
 /// // The memoized instance of `ExampleFormatter` will be re-used.
 /// let result2 = memoizer
-///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), &(), |intl_example| {
 ///         intl_example.format(message2)
 ///     });
 ///
@@ -149,13 +159,13 @@ pub trait Memoizable {
 ///
 /// // Since the constructor args changed, `ExampleFormatter` will be re-constructed.
 /// let result1 = memoizer
-///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), &(), |intl_example| {
 ///         intl_example.format(message1)
 ///     });
 ///
 /// // The memoized instance of `ExampleFormatter` will be re-used.
 /// let result2 = memoizer
-///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), &(), |intl_example| {
 ///         intl_example.format(message2)
 ///     });
 ///
@@ -205,7 +215,12 @@ impl IntlLangMemoizer {
     ///
     /// U - The callback function. Takes an instance of `I` as the first parameter and
     ///     returns the R value.
-    pub fn with_try_get<I, R, U>(&self, construct_args: I::Args, callback: U) -> Result<R, I::Error>
+    pub fn with_try_get<I, R, U>(
+        &self,
+        construct_args: I::Args,
+        data_provider: &I::DataProvider,
+        callback: U,
+    ) -> Result<R, I::Error>
     where
         Self: Sized,
         I: Memoizable + 'static,
@@ -222,7 +237,7 @@ impl IntlLangMemoizer {
         let e = match cache.entry(construct_args.clone()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let val = I::construct(self.lang.clone(), construct_args)?;
+                let val = I::construct(self.lang.clone(), construct_args, data_provider)?;
                 entry.insert(val)
             }
         };
@@ -269,7 +284,8 @@ impl IntlLangMemoizer {
 /// # impl Memoizable for ExampleFormatter {
 /// #     type Args = (String,);
 /// #     type Error = ();
-/// #     fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+/// #     type DataProvider = ();
+/// #     fn construct(lang: LanguageIdentifier, args: Self::Args, data_provider: &Self::DataProvider) -> Result<Self, Self::Error> {
 /// #         Ok(Self {
 /// #             lang,
 /// #             prefix: args.0,
@@ -295,7 +311,7 @@ impl IntlLangMemoizer {
 /// //
 /// // See `IntlLangMemoizer` for more details on this step.
 /// let en_us_result = en_us_memoizer
-///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), &(), |intl_example| {
 ///         intl_example.format(message)
 ///     });
 ///
@@ -312,7 +328,7 @@ impl IntlLangMemoizer {
 /// let de_de_memoizer: Rc<IntlLangMemoizer> = memoizer.get_for_lang(de_de);
 ///
 /// let de_de_result = de_de_memoizer
-///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), |intl_example| {
+///     .with_try_get::<ExampleFormatter, _, _>(construct_args.clone(), &(), |intl_example| {
 ///         intl_example.format(message)
 ///     });
 ///
@@ -380,7 +396,12 @@ mod tests {
     impl Memoizable for PluralRules {
         type Args = (PluralRuleType,);
         type Error = &'static str;
-        fn construct(lang: LanguageIdentifier, args: Self::Args) -> Result<Self, Self::Error> {
+        type DataProvider = ();
+        fn construct(
+            lang: LanguageIdentifier,
+            args: Self::Args,
+            _: &Self::DataProvider,
+        ) -> Result<Self, Self::Error> {
             Self::new(lang, args.0)
         }
     }
@@ -394,7 +415,9 @@ mod tests {
             let en_memoizer = memoizer.get_for_lang(lang.clone());
 
             let result = en_memoizer
-                .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |cb| cb.0.select(5))
+                .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), &(), |cb| {
+                    cb.0.select(5)
+                })
                 .unwrap();
             assert_eq!(result, Ok(PluralCategory::OTHER));
         }
@@ -403,7 +426,9 @@ mod tests {
             let en_memoizer = memoizer.get_for_lang(lang);
 
             let result = en_memoizer
-                .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |cb| cb.0.select(5))
+                .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), &(), |cb| {
+                    cb.0.select(5)
+                })
                 .unwrap();
             assert_eq!(result, Ok(PluralCategory::OTHER));
         }
@@ -420,7 +445,7 @@ mod tests {
             let memoizer = Arc::clone(&memoizer);
             threads.push(thread::spawn(move || {
                 memoizer
-                    .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |cb| {
+                    .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), &(), |cb| {
                         cb.0.select(5)
                     })
                     .expect("Failed to get a PluralRules result.")


### PR DESCRIPTION
Adds basic decimal formatting for FluentNumber.as_string(). Many features are still missing like currency symbols and percentage formatting. #269

Since data providers need to be managed explicitly, it needs to be handed to the memoizer to be able to construct a formatter. This required a new argument + associated type on Memoizable.

Something to figure out is where the data comes from. I've went with a simple FluentBundle.set_number_format_provider, which seems most flexible to me. I've added a test that uses icu_testdata for this, but other providers should work as well.
https://icu4x.unicode.org/doc/icu/#data-management
