### PR TITLE
Fix FluentValue::try_number accepting numbers

### DIFF
--- a/fluent-bundle/src/args.rs
+++ b/fluent-bundle/src/args.rs
@@ -146,7 +146,7 @@ mod tests {
             args.get("name"),
             Some(&FluentValue::String(Cow::Borrowed("John")))
         );
-        assert_eq!(args.get("emailCount"), Some(&FluentValue::try_number(5)));
+        assert_eq!(args.get("emailCount"), Some(&FluentValue::try_number("5")));
 
         args.set("name", "Jane");
         args.set("emailCount", 7);
@@ -155,6 +155,6 @@ mod tests {
             args.get("name"),
             Some(&FluentValue::String(Cow::Borrowed("Jane")))
         );
-        assert_eq!(args.get("emailCount"), Some(&FluentValue::try_number(7)));
+        assert_eq!(args.get("emailCount"), Some(&FluentValue::try_number("7")));
     }
 }

--- a/fluent-bundle/src/resolver/inline_expression.rs
+++ b/fluent-bundle/src/resolver/inline_expression.rs
@@ -53,7 +53,7 @@ impl<'bundle> WriteValue<'bundle> for ast::InlineExpression<&'bundle str> {
                     scope.write_ref_error(w, self)
                 }
             }
-            Self::NumberLiteral { value } => FluentValue::try_number(*value).write(w, scope),
+            Self::NumberLiteral { value } => FluentValue::try_number(value).write(w, scope),
             Self::TermReference {
                 id,
                 attribute,
@@ -158,7 +158,7 @@ impl<'bundle> ResolveValue<'bundle> for ast::InlineExpression<&'bundle str> {
     {
         match self {
             Self::StringLiteral { value } => unescape_unicode_to_string(value).into(),
-            Self::NumberLiteral { value } => FluentValue::try_number(*value),
+            Self::NumberLiteral { value } => FluentValue::try_number(value),
             Self::VariableReference { id } => {
                 if let Some(local_args) = &scope.local_args {
                     if let Some(arg) = local_args.get(id.name) {

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -142,12 +142,11 @@ impl<'source> FluentValue<'source> {
     ///     FluentValue::String("A string".into())
     /// );
     /// ```
-    pub fn try_number<S: ToString>(value: S) -> Self {
-        let string = value.to_string();
-        if let Ok(number) = FluentNumber::from_str(&string) {
+    pub fn try_number(value: &'source str) -> Self {
+        if let Ok(number) = FluentNumber::from_str(value) {
             number.into()
         } else {
-            string.into()
+            value.into()
         }
     }
 

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -247,6 +247,6 @@ mod tests {
         let x = 1i16;
         let y = &x;
         let z: FluentValue = y.into();
-        assert_eq!(z, FluentValue::try_number(1));
+        assert_eq!(z, FluentValue::try_number("1"));
     }
 }

--- a/fluent/tests/macro.rs
+++ b/fluent/tests/macro.rs
@@ -13,7 +13,7 @@ fn test_fluent_args() {
         args.get("name"),
         Some(&FluentValue::String(Cow::Borrowed("John")))
     );
-    assert_eq!(args.get("emailCount"), Some(&FluentValue::try_number(5)));
+    assert_eq!(args.get("emailCount"), Some(&FluentValue::try_number("5")));
     assert_eq!(
         args.get("customValue"),
         Some(&FluentValue::String(Cow::Borrowed("My Value")))


### PR DESCRIPTION
This seems to be a mistake since the documentation only describes its use for parsing strings.
By only accepting &str, there's no need for the to_string() call, making it more efficient. (AsRef<str> is also an option)
Note that this would be a breaking change since it's a public API.
