### PR TITLE
Add type alias for concurrent `FluentBundle`

### DIFF
--- a/fluent-bundle/src/concurrent.rs
+++ b/fluent-bundle/src/concurrent.rs
@@ -2,23 +2,31 @@ use intl_memoizer::{concurrent::IntlLangMemoizer, Memoizable};
 use rustc_hash::FxHashMap;
 use unic_langid::LanguageIdentifier;
 
-use crate::bundle::FluentBundle;
 use crate::memoizer::MemoizerKind;
 use crate::types::FluentType;
 
-impl<R> FluentBundle<R, IntlLangMemoizer> {
+/// Specialized [`FluentBundle`](crate::bundle::FluentBundle) over
+/// concurrent [`IntlLangMemoizer`](intl_memoizer::concurrent::IntlLangMemoizer).
+///
+/// A concurrent `FluentBundle` can be constructed with the
+/// [`FluentBundle::new_concurrent`] method.
+///
+/// See [`FluentBundle`](crate::FluentBundle) for the non-concurrent specialization.
+pub type FluentBundle<R> = crate::bundle::FluentBundle<R, IntlLangMemoizer>;
+
+impl<R> FluentBundle<R> {
     /// A constructor analogous to [`FluentBundle::new`] but operating
     /// on a concurrent version of [`IntlLangMemoizer`] over [`Mutex`](std::sync::Mutex).
     ///
     /// # Example
     ///
     /// ```
-    /// use fluent_bundle::bundle::FluentBundle;
+    /// use fluent_bundle::concurrent::FluentBundle;
     /// use fluent_bundle::FluentResource;
     /// use unic_langid::langid;
     ///
     /// let langid_en = langid!("en-US");
-    /// let mut bundle: FluentBundle<FluentResource, _> =
+    /// let mut bundle: FluentBundle<FluentResource> =
     ///     FluentBundle::new_concurrent(vec![langid_en]);
     /// ```
     pub fn new_concurrent(locales: Vec<LanguageIdentifier>) -> Self {

--- a/fluent-bundle/src/lib.rs
+++ b/fluent-bundle/src/lib.rs
@@ -100,7 +100,7 @@
 //! matures and higher level APIs are being developed.
 mod args;
 pub mod bundle;
-mod concurrent;
+pub mod concurrent;
 mod entry;
 mod errors;
 #[doc(hidden)]
@@ -117,8 +117,8 @@ pub use args::FluentArgs;
 ///
 /// This is the basic variant of the [`FluentBundle`](crate::bundle::FluentBundle).
 ///
-/// The concurrent specialization, can be constructed with
-/// [`FluentBundle::new_concurrent`](crate::bundle::FluentBundle::new_concurrent).
+/// The concurrent specialization can be constructed with
+/// [`FluentBundle::new_concurrent`](crate::concurrent::FluentBundle::new_concurrent).
 pub type FluentBundle<R> = bundle::FluentBundle<R, intl_memoizer::IntlLangMemoizer>;
 pub use errors::FluentError;
 pub use message::{FluentAttribute, FluentMessage};


### PR DESCRIPTION
As per the comment in #299.

I've created this alias in the `concurrent` module. That seemed like the best place to put it imo, but in order to do that I had to make the module public. I hope that's not a problem.

Cheers.