### PR TITLE
Treat tab as text, not whitespace

### DIFF
--- a/fluent-syntax/src/parser/slice.rs
+++ b/fluent-syntax/src/parser/slice.rs
@@ -10,7 +10,9 @@ impl<'s> Slice<'s> for String {
     }
 
     fn trim(&mut self) {
-        *self = self.trim_end().to_string();
+        *self = self
+            .trim_end_matches(|c| c == ' ' || c == '\r' || c == '\n')
+            .to_string();
     }
 }
 
@@ -20,6 +22,6 @@ impl<'s> Slice<'s> for &'s str {
     }
 
     fn trim(&mut self) {
-        *self = self.trim_end();
+        *self = self.trim_end_matches(|c| c == ' ' || c == '\r' || c == '\n');
     }
 }

--- a/fluent-syntax/src/serializer.rs
+++ b/fluent-syntax/src/serializer.rs
@@ -118,7 +118,11 @@ impl Serializer {
         for line in &comment.content {
             self.writer.write_literal(prefix);
 
-            if !line.as_ref().trim().is_empty() {
+            if !line
+                .as_ref()
+                .trim_matches(|c| c == ' ' || c == '\r' || c == '\n')
+                .is_empty()
+            {
                 self.writer.write_literal(" ");
                 self.writer.write_literal(line.as_ref());
             }

--- a/fluent-syntax/tests/fixtures/tab.ftl
+++ b/fluent-syntax/tests/fixtures/tab.ftl
@@ -12,3 +12,10 @@ key03 =
 key04 =
     This line is indented by 4 spaces,
 	whereas this line by 1 tab.
+
+# OK (value is a single tab)
+key05 = 	
+
+# OK (attribute value is two tabs)
+key06 =
+  .attr = 		

--- a/fluent-syntax/tests/fixtures/tab.json
+++ b/fluent-syntax/tests/fixtures/tab.json
@@ -64,7 +64,58 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "\twhereas this line by 1 tab.\n"
+            "content": "\twhereas this line by 1 tab.\n\n"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key05"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "\t"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "OK (value is a single tab)"
+            }
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key06"
+            },
+            "value": null,
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "\t\t"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": {
+                "type": "Comment",
+                "content": "OK (attribute value is two tabs)"
+            }
         }
     ]
 }


### PR DESCRIPTION
See https://github.com/projectfluent/python-fluent/issues/173

Tabs were defined to be text, not whitespace, in https://github.com/projectfluent/fluent/pull/167, but this change was not reflected here.