### PR TITLE
fluent-bundle: Bump serde_yaml to 0.9 from 0.8

### DIFF
--- a/fluent-bundle/CHANGELOG.md
+++ b/fluent-bundle/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-  - …
+  - Bump `serde_yaml` to 0.9.
 
 ## fluent-bundle 0.15.2 (October 25, 2021)
   - Bump `self_cell` to 0.10.

--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -41,7 +41,7 @@ iai.workspace = true
 serde = { workspace = true, features = ["derive"]}
 unic-langid = { workspace = true, features = ["macros"] }
 rand = "0.8"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 
 [features]
 default = []


### PR DESCRIPTION
0.9 was released about 8 months ago. There were breaking changes listed at the time:

https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0

It does build and pass tests though ...

