### PR TITLE
ci: Update actions/checkout to v3 from v2 and v1.

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,6 +16,6 @@ jobs:
           override: true
           components: rustfmt
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run rustfmt
         run: cargo fmt --check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
           - ''
           - '--all-features'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
This only updates `actions/checkout` and not `actions/cache` or others that may need updating.