### PR TITLE
ci: Stop using `actions-rs/toolchain`.

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,10 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Toolchain setup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
           components: rustfmt
 
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,10 +38,9 @@ jobs:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}
       - name: Toolchain setup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
           components: llvm-tools-preview
       - name: Install grcov
         if: matrix.rust-version == 'nightly' && matrix.cargo-args == '--all-features'


### PR DESCRIPTION
The `actions-rs` actions haven't been maintained in some time and result in a number of deprecation warnings from GitHub Actions.