### PR TITLE
Use "resolver = 2" in the virtual workspace.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "fluent-syntax",
     "fluent-bundle",


### PR DESCRIPTION
This is the default for 2021 edition crates, but not for a virtual workspace, so it must be set explicitly.