### PR TITLE
ci: Update to `actions/checkout@v4`.

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,6 +16,6 @@ jobs:
           override: true
           components: rustfmt
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run rustfmt
         run: cargo fmt --check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
           - ''
           - '--all-features'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
This is just keeping up with the Node updates within the GitHub Actions infrastructure.