### PR TITLE
ci: Use `-C` rather than `-Z` for instrument-coverage.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         run: cargo test --all-features --no-fail-fast
         env:
-          RUSTFLAGS: '-Zinstrument-coverage'
+          RUSTFLAGS: '-Cinstrument-coverage'
       - name: Run grcov
         if: matrix.rust-version == 'nightly' && matrix.cargo-args == '--all-features'
         # Important! Keep in grcov flags in sync with Makefile.internal.toml.


### PR DESCRIPTION
Using `-C` was stabilized in Rust 1.60.