### PR TITLE
Add Capability to Localize Terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 /target/
 */target/
 **/*.rs.bk

--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -23,6 +23,7 @@ use crate::memoizer::MemoizerKind;
 use crate::message::FluentMessage;
 use crate::resolver::{ResolveValue, Scope, WriteValue};
 use crate::resource::FluentResource;
+use crate::term::FluentTerm;
 use crate::types::FluentValue;
 
 /// A collection of localization messages for a single locale, which are meant
@@ -378,6 +379,13 @@ impl<R, M> FluentBundle<R, M> {
         self.get_entry_message(id).is_some()
     }
 
+    pub fn has_term(&self, id: &str) -> bool
+    where
+        R: Borrow<FluentResource>,
+    {
+        self.get_entry_term(id).is_some()
+    }
+
     /// Retrieves a `FluentMessage` from a bundle.
     ///
     /// # Examples
@@ -404,6 +412,13 @@ impl<R, M> FluentBundle<R, M> {
         R: Borrow<FluentResource>,
     {
         self.get_entry_message(id).map(Into::into)
+    }
+
+    pub fn get_term<'l>(&'l self, id: &str) -> Option<FluentTerm<'l>>
+    where
+        R: Borrow<FluentResource>,
+    {
+        self.get_entry_term(id).map(Into::into)
     }
 
     /// Writes a formatted pattern which comes from a `FluentMessage`.

--- a/fluent-bundle/src/lib.rs
+++ b/fluent-bundle/src/lib.rs
@@ -109,6 +109,7 @@ mod message;
 #[doc(hidden)]
 pub mod resolver;
 mod resource;
+mod term;
 pub mod types;
 
 pub use args::FluentArgs;

--- a/fluent-bundle/src/term.rs
+++ b/fluent-bundle/src/term.rs
@@ -8,8 +8,8 @@ pub struct FluentTerm<'t> {
 }
 
 impl<'t> FluentTerm<'t> {
-    pub fn value(&self) -> Option<&'t ast::Pattern<&'t str>> {
-        self.node.value.as_ref()
+    pub fn value(&self) -> &'t ast::Pattern<&'t str> {
+        &self.node.value
     }
 
     pub fn attributes(&self) -> impl Iterator<Item = FluentAttribute<'t>> {

--- a/fluent-bundle/src/term.rs
+++ b/fluent-bundle/src/term.rs
@@ -1,0 +1,32 @@
+use fluent_syntax::ast;
+
+use crate::message::FluentAttribute;
+
+#[derive(Debug, PartialEq)]
+pub struct FluentTerm<'t> {
+    node: &'t ast::Term<&'t str>,
+}
+
+impl<'t> FluentTerm<'t> {
+    pub fn value(&self) -> Option<&'t ast::Pattern<&'t str>> {
+        self.node.value.as_ref()
+    }
+
+    pub fn attributes(&self) -> impl Iterator<Item = FluentAttribute<'t>> {
+        self.node.attributes.iter().map(Into::into)
+    }
+
+    pub fn get_attribute(&self, key: &str) -> Option<FluentAttribute<'t>> {
+        self.node
+            .attributes
+            .iter()
+            .find(|attr| attr.id.name == key)
+            .map(Into::into)
+    }
+}
+
+impl<'t> From<&'t ast::Term<&'t str>> for FluentTerm<'t> {
+    fn from(term: &'t ast::Term<&'t str>) -> Self {
+        FluentTerm { node: term }
+    }
+}


### PR DESCRIPTION
This PR adds a `get_term` method such that terms can also be localized via a similar API to that of messages.