### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,17 +23,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo binaries
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
This PR includes changes from:
- #332: Use -C rathen than -Z for instrument-coverage
- #320: Replace unmaintained `actions-rs/toolchain` with `dtolnay/rust-toolchain`

It also updates `actions/cache` to v4.