### PR TITLE
chore: Release 'safe harbor' versions of Fluent workspace crates

### DIFF
--- a/fluent-bundle/CHANGELOG.md
+++ b/fluent-bundle/CHANGELOG.md
@@ -4,6 +4,21 @@
 
   - …
 
+## fluent-bundle 0.15.3 (March 16, 2024)
+  - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers
+  - Implement `From<&String>` for `FluentValue`
+  - Add `FluentValue.into_string` to prevent String clone
+  - Fix `FluentValue::try_number` accepting numbers
+  - Allow optional arguments on `FluentValue`
+  - Fix behavior of `FluentArgs::set`
+  - Resolve function instead in `impl ResolveValue`
+  - Add type alias for concurrent `FluentBundle`
+  - Fix `FluentBundle::format_pattern` lifetimes
+  - Workspace: Update to Rust 2021
+  - Workspace: Add various missing documentation and fix typos and links
+  - Workspace: Cleanup meta-data using workspaces, use SPDX licenses, etc.
+  - Workspace: Apply rustfmt and clippy lint fixes
+
 ## fluent-bundle 0.15.2 (October 25, 2021)
   - Bump `self_cell` to 0.10.
 

--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 A localization system designed to unleash the entire expressive power of
 natural language translations.
 """
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 authors = [
     "Zibi Braniecki <zibi@unicode.org>",

--- a/fluent-fallback/CHANGELOG.md
+++ b/fluent-fallback/CHANGELOG.md
@@ -4,6 +4,14 @@
 
   - …
 
+## fluent-fallback 0.7.1 (March 16, 2024)
+  - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers
+  - Migrate to `pin_cell` crate
+  - Workspace: Update to Rust 2021
+  - Workspace: Add various missing documentation and fix typos and links
+  - Workspace: Cleanup meta-data using workspaces, use SPDX licenses, etc.
+  - Workspace: Apply rustfmt and clippy lint fixes
+
 ## fluent-fallback 0.7.0 (Nov 9, 2022)
   - The `ResourceId`s are now stored as a `HashSet` rather than as a Vec. Adding a
     duplicate `ResourceId` is now a noop.

--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 High-level abstraction model for managing localization resources
 and runtime localization lifecycle.
 """
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = [
     "Zibi Braniecki <zibi@unicode.org>",

--- a/fluent-pseudo/CHANGELOG.md
+++ b/fluent-pseudo/CHANGELOG.md
@@ -4,6 +4,14 @@
 
   - …
 
+## fluent-pseudo 0.3.2 (March 16, 2024)
+  - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers
+  - Allow optional resources, adds `ResourceId` struct
+  - Workspace: Update to Rust 2021
+  - Workspace: Add various missing documentation and fix typos and links
+  - Workspace: Cleanup meta-data using workspaces, use SPDX licenses, etc.
+  - Workspace: Apply rustfmt and clippy lint fixes
+
 ## fluent-pseudo 0.3.1 (July 21, 2021)
   - Update README to document the API changes in 0.3.0.
 

--- a/fluent-pseudo/Cargo.toml
+++ b/fluent-pseudo/Cargo.toml
@@ -3,7 +3,7 @@ name = "fluent-pseudo"
 description = """
 Pseudolocalization transformation API for use with Project Fluent API.
 """
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = [
     "Zibi Braniecki <zibi@unicode.org>",

--- a/fluent-resmgr/CHANGELOG.md
+++ b/fluent-resmgr/CHANGELOG.md
@@ -4,6 +4,14 @@
 
   - …
 
+## fluent-resmgr 0.0.7 (March 16, 2024)
+  - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers
+  - Return a result for `ResourceManager::get_resource`
+  - Workspace: Update to Rust 2021
+  - Workspace: Add various missing documentation and fix typos and links
+  - Workspace: Cleanup meta-data using workspaces, use SPDX licenses, etc.
+  - Workspace: Apply rustfmt and clippy lint fixes
+
 ## fluent-resmgr 0.0.6 (Nov 9, 2022)
   - Update `fluent-fallback` to 0.7.0.
 

--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -3,7 +3,7 @@ name = "fluent-resmgr"
 description = """
 Resource manager for Fluent localization resources.
 """
-version = "0.0.6"
+version = "0.0.7"
 authors = [
     "Zibi Braniecki <zibi@unicode.org>",
     "Staś Małolepszy <stas@mozilla.com>"

--- a/fluent-syntax/CHANGELOG.md
+++ b/fluent-syntax/CHANGELOG.md
@@ -4,6 +4,16 @@
   - Add module `serializer`.
   - …
 
+## fluent-syntax 0.11.1 (March 16, 2024)
+  - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers
+  - Create generic ftl serializer `fluent_syntax::serializer`
+  - Fix crash when parsing multiline CRLF comment
+  - Treat tab as text, not whitespace, adds `parser::matches_fluent_ws` function
+  - Workspace: Update to Rust 2021
+  - Workspace: Add various missing documentation and fix typos and links
+  - Workspace: Cleanup meta-data using workspaces, use SPDX licenses, etc.
+  - Workspace: Apply rustfmt and clippy lint fixes
+
 ## fluent-syntax 0.11.0 (February 9, 2021)
   - Document the crate.
   - Switch to use `thiserror` for Error annotations.

--- a/fluent-syntax/Cargo.toml
+++ b/fluent-syntax/Cargo.toml
@@ -3,7 +3,7 @@ name = "fluent-syntax"
 description = """
 Parser/Serializer tools for Fluent Syntax.
 """
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = [
     "Zibi Braniecki <zibi@unicode.org>",

--- a/fluent-testing/CHANGELOG.md
+++ b/fluent-testing/CHANGELOG.md
@@ -4,6 +4,13 @@
 
   - …
 
+## fluent-testing 0.0.4 (March 16, 2024)
+  - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers
+  - Workspace: Update to Rust 2021
+  - Workspace: Add various missing documentation and fix typos and links
+  - Workspace: Cleanup meta-data using workspaces, use SPDX licenses, etc.
+  - Workspace: Apply rustfmt and clippy lint fixes
+
 ## fluent-resmgr 0.0.3 (Nov 9, 2022)
   - Update `fluent-fallback` to 0.7.0.
 

--- a/fluent-testing/Cargo.toml
+++ b/fluent-testing/Cargo.toml
@@ -3,7 +3,7 @@ name = "fluent-testing"
 description = """
 A collection of mock scenarios for testing fluent-rs components.
 """
-version = "0.0.3"
+version = "0.0.4"
 authors = [
     "Zibi Braniecki <zibi@braniecki.net>",
     "Erik Nordin <enordin@mozilla.com>"

--- a/fluent/CHANGELOG.md
+++ b/fluent/CHANGELOG.md
@@ -4,6 +4,15 @@
 
   - …
 
+## fluent 0.16.1 (March 16, 2024)
+  - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers
+  - Make `fluent_args` macro work with trailing comma
+  - Fix `FluentValue::try_number` accepting numbers
+  - Workspace: Update to Rust 2021
+  - Workspace: Add various missing documentation and fix typos and links
+  - Workspace: Cleanup meta-data using workspaces, use SPDX licenses, etc.
+  - Workspace: Apply rustfmt and clippy lint fixes
+
 ## fluent 0.16.0 (July 29, 2021)
   - Update `fluent-pseudo` to 0.3.
 

--- a/fluent/Cargo.toml
+++ b/fluent/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 A localization system designed to unleash the entire expressive power of
 natural language translations.
 """
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 authors = [
     "Zibi Braniecki <zibi@unicode.org>",

--- a/intl-memoizer/CHANGELOG.md
+++ b/intl-memoizer/CHANGELOG.md
@@ -4,6 +4,13 @@
 
   - …
 
+## intl-memoizer 0.5.2 (March 16, 2024)
+  - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers
+  - Workspace: Update to Rust 2021
+  - Workspace: Add various missing documentation and fix typos and links
+  - Workspace: Cleanup meta-data using workspaces, use SPDX licenses, etc.
+  - Workspace: Apply rustfmt and clippy lint fixes
+
 ## intl-memoizer 0.5.1 (January 22, 2021)
   - Update `type-map` to 0.4.
 

--- a/intl-memoizer/Cargo.toml
+++ b/intl-memoizer/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 A memoizer specifically tailored for storing lazy-initialized
 intl formatters.
 """
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = [
     "Zibi Braniecki <zibi@unicode.org>",


### PR DESCRIPTION
These releases serve as a markers in the transition from the Project Fluent related crates being a wholly Mozilla managed project to bringing on non-Mozilla community maintainers. The safe harbor release series publishes the current Git HEAD of all crates as a convenience to downstream consumers that either audit the code and contributors, don't want to adopt potential changes for whatever reason, or just want an easy reference point against which to compare future releases.

Closes #347

----

Related issues:

* Background to bringing on non-Mozilla maintainers:
  https://github.com/projectfluent/fluent/issues/358

* Matching PR for fluent-langneg that is in a different workspace:
  https://github.com/projectfluent/fluent-langneg-rs/pull/27
