### PR TITLE
Bump compatible minor version updates to crates

### DIFF
--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -32,8 +32,8 @@ intl_pluralrules.workspace = true
 rustc-hash.workspace = true
 unic-langid.workspace = true
 intl-memoizer = { path = "../intl-memoizer" }
-self_cell = "0.10"
-smallvec = "1"
+self_cell = "1.0"
+smallvec = "1.13"
 
 [dev-dependencies]
 criterion.workspace = true

--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -24,7 +24,7 @@ rustc-hash.workspace = true
 unic-langid.workspace = true
 async-trait = "0.1"
 chunky-vec = "0.1"
-once_cell = "1.9"
+once_cell = "1.19"
 pin-cell = "0.2"
 
 [dev-dependencies]

--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -23,7 +23,7 @@ futures.workspace = true
 rustc-hash.workspace = true
 thiserror.workspace = true
 unic-langid.workspace = true
-elsa = "1.5"
+elsa = "1.10"
 
 [dev-dependencies]
 fluent-langneg.workspace = true


### PR DESCRIPTION
Follow up to #316. Includes all compatible minor version bumps except serde_yaml.
