### PR TITLE
Bump criterion to 0.5 to avoid dependency on atty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [workspace.dependencies]
-criterion = "0.3"
+criterion = "0.5"
 fluent-langneg = "0.13"
 futures = "0.3"
 iai = "0.1"


### PR DESCRIPTION
Criterion before 0.5 depended on atty which is affected by [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145)