### PR TITLE
refactor: Derive `Default` for enums

### DIFF
--- a/fluent-bundle/examples/custom_type.rs
+++ b/fluent-bundle/examples/custom_type.rs
@@ -21,19 +21,14 @@ use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
 //  - timeStyle
 //
 // with an enum of allowed values.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Hash)]
 enum DateTimeStyleValue {
     Full,
     Long,
     Medium,
     Short,
+    #[default]
     None,
-}
-
-impl std::default::Default for DateTimeStyleValue {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 // This is just a helper to make it easier to convert

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -8,17 +8,12 @@ use intl_pluralrules::operands::PluralOperands;
 use crate::args::FluentArgs;
 use crate::types::FluentValue;
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Default, Hash, PartialEq, Eq)]
 pub enum FluentNumberStyle {
+    #[default]
     Decimal,
     Currency,
     Percent,
-}
-
-impl std::default::Default for FluentNumberStyle {
-    fn default() -> Self {
-        Self::Decimal
-    }
 }
 
 impl From<&str> for FluentNumberStyle {
@@ -32,17 +27,12 @@ impl From<&str> for FluentNumberStyle {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Default, Hash, PartialEq, Eq)]
 pub enum FluentNumberCurrencyDisplayStyle {
+    #[default]
     Symbol,
     Code,
     Name,
-}
-
-impl std::default::Default for FluentNumberCurrencyDisplayStyle {
-    fn default() -> Self {
-        Self::Symbol
-    }
 }
 
 impl From<&str> for FluentNumberCurrencyDisplayStyle {

--- a/fluent-bundle/tests/custom_types.rs
+++ b/fluent-bundle/tests/custom_types.rs
@@ -47,19 +47,14 @@ fn fluent_custom_type() {
 
 #[test]
 fn fluent_date_time_builtin() {
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(Debug, Default, PartialEq, Clone)]
     enum DateTimeStyleValue {
         Full,
         Long,
         Medium,
         Short,
+        #[default]
         None,
-    }
-
-    impl std::default::Default for DateTimeStyleValue {
-        fn default() -> Self {
-            Self::None
-        }
     }
 
     impl<'l> From<&FluentValue<'l>> for DateTimeStyleValue {


### PR DESCRIPTION
As of Rust 1.62, enums can use `#[derive(Default)]`.

See <https://github.com/rust-lang/rust/pull/94457>.