### PR TITLE
Fix syntax error in CI run

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -20,4 +20,4 @@ jobs:
           components: rustfmt
 
       - name: Clippy
-        run: cargo clippy -- --all-features -Dwarnings
+        run: cargo clippy --all-features -- -Dwarnings


### PR DESCRIPTION
Follow up to #342 which didn't surface the error because actions don't run in PRs until they have been merged to the default branch