### PR TITLE
Cleanup up READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
 a localization system designed to unleash the entire expressive power of natural language translations.
 
+Project Fluent keeps simple things simple and makes complex things possible.
+The syntax used for describing translations is easy to read and understand.
+At the same time it allows, when necessary, to represent complex concepts from natural languages like gender, plurals, conjugations, and others.
+
 ## Packages
 
 This workspace contains the following crates:

--- a/README.md
+++ b/README.md
@@ -29,26 +29,3 @@ Resource Manager for localization resources.
 ### fluent-cli
 
 Collection of command line tools for Fluent.
-
-## Running the project
-
-Each `fluent-*` directory works with the typical `cargo` commands. In addition there are some general `cargo-make` commands that can be run. First install `cargo-make` via `cargo install --force cargo-make`. The commands are documented in [Makefile.toml](Makefile.toml).
-
-### Tests
-
-To run all of the tests for the repo run:
-
-```sh
-cargo make test
-```
-
-For local code coverage reports run:
-
-```sh
-# Install the tools first if you haven't done so. The llvm tools must be available
-# on the path for this to work correctly.
-cargo make install-tools
-
-# Then coverage can be run like so:
-cargo make coverage
-```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ An umbrella crate exposing the combined features of fluent-rs crates with additi
 [![crates.io](https://img.shields.io/crates/v/fluent_bundle.svg)](https://crates.io/crates/fluent_bundle)
 [![docs.rs](https://img.shields.io/docsrs/fluent-bundle)](https://docs.rs/fluent-bundle)
 
-A low level implementation of a collection of localization messages for a single locale.
+A low-level implementation of a collection of localization messages for a single locale.
 
 ### fluent-fallback
 
@@ -40,14 +40,14 @@ A high-level abstraction model for managing locale bundles and runtime localizat
 [![crates.io](https://img.shields.io/crates/v/fluent_resmgr.svg)](https://crates.io/crates/fluent_resmgr)
 [![docs.rs](https://img.shields.io/docsrs/fluent-resmgr)](https://docs.rs/fluent-resmgr)
 
-A standalone solution for managing localization resource files and returning locale bundles.
+A standalone solution for managing resource files and returning locale bundles.
 
 ### fluent-syntax
 
 [![crates.io](https://img.shields.io/crates/v/fluent_syntax.svg)](https://crates.io/crates/fluent_syntax)
 [![docs.rs](https://img.shields.io/docsrs/fluent-syntax)](https://docs.rs/fluent-syntax)
 
-The low level parser, AST, and serializer APIs for the Fluent Syntax.
+A low-level parser, AST, and serializer API for the Fluent syntax.
 
 ### fluent-pseudo
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Fluent [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml) [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
+# Project Fluent
+
+[![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
 The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
 a localization system designed to unleash the entire expressive power of natural language translations.
@@ -7,35 +10,59 @@ a localization system designed to unleash the entire expressive power of natural
 
 This workspace contains the following crates:
 
-### fluent [![crates.io](https://img.shields.io/crates/v/fluent.svg)](https://crates.io/crates/fluent)
+### fluent
+
+[![crates.io](https://img.shields.io/crates/v/fluent.svg)](https://crates.io/crates/fluent)
+[![docs.rs](https://img.shields.io/docsrs/fluent)](https://docs.rs/fluent)
 
 An umbrella crate exposing the combined features of fluent-rs crates with additional convenience macros.
 
-### fluent-bundle [![crates.io](https://img.shields.io/crates/v/fluent_bundle.svg)](https://crates.io/crates/fluent_bundle)
+### fluent-bundle
+
+[![crates.io](https://img.shields.io/crates/v/fluent_bundle.svg)](https://crates.io/crates/fluent_bundle)
+[![docs.rs](https://img.shields.io/docsrs/fluent-bundle)](https://docs.rs/fluent-bundle)
 
 A low level implementation of a collection of localization messages for a single locale.
 
-### fluent-fallback [![crates.io](https://img.shields.io/crates/v/fluent_fallback.svg)](https://crates.io/crates/fluent_fallback)
+### fluent-fallback
+
+[![crates.io](https://img.shields.io/crates/v/fluent_fallback.svg)](https://crates.io/crates/fluent_fallback)
+[![docs.rs](https://img.shields.io/docsrs/fluent-fallback)](https://docs.rs/fluent-fallback)
 
 A high-level abstraction model for managing locale bundles and runtime localization lifecycle.
 
-### fluent-resmgr [![crates.io](https://img.shields.io/crates/v/fluent_resmgr.svg)](https://crates.io/crates/fluent_resmgr)
+### fluent-resmgr
+
+[![crates.io](https://img.shields.io/crates/v/fluent_resmgr.svg)](https://crates.io/crates/fluent_resmgr)
+[![docs.rs](https://img.shields.io/docsrs/fluent-resmgr)](https://docs.rs/fluent-resmgr)
 
 A standalone solution for managing localization resource files and returning locale bundles.
 
-### fluent-syntax [![crates.io](https://img.shields.io/crates/v/fluent_syntax.svg)](https://crates.io/crates/fluent_syntax)
+### fluent-syntax
+
+[![crates.io](https://img.shields.io/crates/v/fluent_syntax.svg)](https://crates.io/crates/fluent_syntax)
+[![docs.rs](https://img.shields.io/docsrs/fluent-syntax)](https://docs.rs/fluent-syntax)
 
 The low level parser, AST, and serializer APIs for the Fluent Syntax.
 
-### fluent-pseudo [![crates.io](https://img.shields.io/crates/v/fluent_pseudo.svg)](https://crates.io/crates/fluent_pseudo)
+### fluent-pseudo
+
+[![crates.io](https://img.shields.io/crates/v/fluent_pseudo.svg)](https://crates.io/crates/fluent_pseudo)
+[![docs.rs](https://img.shields.io/docsrs/fluent-pseudo)](https://docs.rs/fluent-pseudo)
 
 A pseudolocalization and transformation API.
 
-### fluent-testing [![crates.io](https://img.shields.io/crates/v/fluent_testing.svg)](https://crates.io/crates/fluent_testing)
+### fluent-testing
+
+[![crates.io](https://img.shields.io/crates/v/fluent_testing.svg)](https://crates.io/crates/fluent_testing)
+[![docs.rs](https://img.shields.io/docsrs/fluent-testing)](https://docs.rs/fluent-testing)
 
 A collection of mock scenarios for testing fluent-rs components.
 
-### intl-memoizer [![crates.io](https://img.shields.io/crates/v/fluent_testing.svg)](https://crates.io/crates/fluent_testing)
+### intl-memoizer
+
+[![crates.io](https://img.shields.io/crates/v/fluent_testing.svg)](https://crates.io/crates/fluent_testing)
+[![docs.rs](https://img.shields.io/docsrs/intl-memoizer)](https://docs.rs/intl-memoizer)
 
 A memoizer specifically tailored for storing lazy-initialized intl formatters.
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,46 @@
 # Fluent [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml) [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
-`fluent-rs` is a collection of Rust crates implementing [Project Fluent](https://projectfluent.org).
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
 
 ## Packages
 
-The crates perform the following functions:
+This workspace contains the following crates:
 
 ### fluent [![crates.io](https://img.shields.io/crates/v/fluent.svg)](https://crates.io/crates/fluent)
 
-Umbrella crate combining crates that are ready to be used in production.
-
-### fluent-syntax [![crates.io](https://img.shields.io/crates/v/fluent_syntax.svg)](https://crates.io/crates/fluent_syntax)
-
-Low level Fluent Syntax AST and parser API.
+An umbrella crate exposing the combined features of fluent-rs crates with additional convenience macros.
 
 ### fluent-bundle [![crates.io](https://img.shields.io/crates/v/fluent_bundle.svg)](https://crates.io/crates/fluent_bundle)
 
-Implementation of the low-level Fluent Localization System providing localization capabilities for any Rust project.
+A low level implementation of a collection of localization messages for a single locale.
 
 ### fluent-fallback [![crates.io](https://img.shields.io/crates/v/fluent_fallback.svg)](https://crates.io/crates/fluent_fallback)
 
-Implementation of the high-level Fluent Localization System providing localization capabilities for any Rust project.
+A high-level abstraction model for managing locale bundles and runtime localization lifecycle.
 
 ### fluent-resmgr [![crates.io](https://img.shields.io/crates/v/fluent_resmgr.svg)](https://crates.io/crates/fluent_resmgr)
 
-Resource Manager for localization resources.
+A standalone solution for managing localization resource files and returning locale bundles.
+
+### fluent-syntax [![crates.io](https://img.shields.io/crates/v/fluent_syntax.svg)](https://crates.io/crates/fluent_syntax)
+
+The low level parser, AST, and serializer APIs for the Fluent Syntax.
+
+### fluent-pseudo [![crates.io](https://img.shields.io/crates/v/fluent_pseudo.svg)](https://crates.io/crates/fluent_pseudo)
+
+A pseudolocalization and transformation API.
+
+### fluent-testing [![crates.io](https://img.shields.io/crates/v/fluent_testing.svg)](https://crates.io/crates/fluent_testing)
+
+A collection of mock scenarios for testing fluent-rs components.
+
+### intl-memoizer [![crates.io](https://img.shields.io/crates/v/fluent_testing.svg)](https://crates.io/crates/fluent_testing)
+
+A memoizer specifically tailored for storing lazy-initialized intl formatters.
 
 ### fluent-cli
 
-Collection of command line tools for Fluent.
+A collection of developer-oriented command line tools for Fluent.
+
+[Project Fluent]: https://projectfluent.org

--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "fluent-bundle"
 description = """
-A localization system designed to unleash the entire expressive power of
-natural language translations.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. This crate exposes a low
+level implementation of a collection of localization messages for a single
+locale.
 """
 version = "0.15.3"
 edition.workspace = true

--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "fluent-bundle"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. This crate exposes a low
-level implementation of a collection of localization messages for a single
-locale.
+A low-level implementation of a collection of localization messages for a single locale for Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.15.3"
 edition.workspace = true

--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -1,8 +1,9 @@
-# Fluent
+# Fluent Bundle
 
-`fluent-rs` is a Rust implementation of [Project Fluent][], a localization
-framework designed to unleash the entire expressive power of natural language
-translations.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate exposes a low level implementation of a collection of localization messages for a single locale.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-bundle.svg)](https://crates.io/crates/fluent-bundle)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
@@ -15,7 +16,7 @@ natural languages like gender, plurals, conjugations, and others.
 
 [Documentation][]
 
-[Project Fluent]: http://projectfluent.org
+[Project Fluent]: https://projectfluent.org
 [Documentation]: https://docs.rs/fluent/
 
 Usage

--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -6,6 +6,7 @@ a localization system designed to unleash the entire expressive power of natural
 This crate exposes a low level implementation of a collection of localization messages for a single locale.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-bundle.svg)](https://crates.io/crates/fluent-bundle)
+[![docs.rs](https://img.shields.io/docsrs/fluent-bundle)](https://docs.rs/fluent-bundle)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 

--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -8,7 +8,7 @@
 The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
 a localization system designed to unleash the entire expressive power of natural language translations.
 
-This crate exposes a low level implementation of a collection of localization messages for a single locale.
+This crate is a low-level implementation of a collection of localization messages for a single locale.
 
 [Project Fluent]: https://projectfluent.org
 

--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -57,20 +57,6 @@ release planning and scope.
 
 [list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
 
-
-Local Development
------------------
-
-    cargo build
-    cargo test
-    cargo bench
-    cargo run --example simple-app
-
-When submitting a PR please use  [`cargo fmt`][] (nightly).
-
-[`cargo fmt`]: https://github.com/rust-lang-nursery/rustfmt
-
-
 Learn the FTL syntax
 --------------------
 

--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -48,15 +48,6 @@ fn main() {
 ```
 
 
-Status
-------
-
-The implementation is in its early stages and supports only some of the Project
-Fluent's spec.  Consult the [list of milestones][] for more information about
-release planning and scope.
-
-[list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
-
 Learn the FTL syntax
 --------------------
 

--- a/fluent-bundle/README.md
+++ b/fluent-bundle/README.md
@@ -1,24 +1,16 @@
 # Fluent Bundle
 
-The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
-a localization system designed to unleash the entire expressive power of natural language translations.
-
-This crate exposes a low level implementation of a collection of localization messages for a single locale.
-
 [![crates.io](https://img.shields.io/crates/v/fluent-bundle.svg)](https://crates.io/crates/fluent-bundle)
 [![docs.rs](https://img.shields.io/docsrs/fluent-bundle)](https://docs.rs/fluent-bundle)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
-Project Fluent keeps simple things simple and makes complex things possible.
-The syntax used for describing translations is easy to read and understand.  At
-the same time it allows, when necessary, to represent complex concepts from
-natural languages like gender, plurals, conjugations, and others.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
 
-[Documentation][]
+This crate exposes a low level implementation of a collection of localization messages for a single locale.
 
 [Project Fluent]: https://projectfluent.org
-[Documentation]: https://docs.rs/fluent/
 
 Usage
 -----
@@ -48,26 +40,6 @@ fn main() {
     assert_eq!(&value, "Hello, world!");
 }
 ```
-
-
-Learn the FTL syntax
---------------------
-
-FTL is a localization file format used for describing translation resources.
-FTL stands for _Fluent Translation List_.
-
-FTL is designed to be simple to read, but at the same time allows to represent
-complex concepts from natural languages like gender, plurals, conjugations, and
-others.
-
-    hello-user = Hello, { $username }!
-
-[Read the Fluent Syntax Guide][] in order to learn more about the syntax.  If
-you're a tool author you may be interested in the formal [EBNF grammar][].
-
-[Read the Fluent Syntax Guide]: http://projectfluent.org/fluent/guide/
-[EBNF grammar]: https://github.com/projectfluent/fluent/tree/master/spec
-
 
 Get Involved
 ------------

--- a/fluent-cli/Cargo.toml
+++ b/fluent-cli/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "fluent-cli"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. This crate is
-collection of developer-oriented command line interface tools.
+A collection of developer-oriented command line interface tools for Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.0.1"
 edition.workspace = true

--- a/fluent-cli/Cargo.toml
+++ b/fluent-cli/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "fluent-cli"
 description = """
-A collection of command line interface programs
-for Fluent Localization System.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. This crate is
+collection of developer-oriented command line interface tools.
 """
 version = "0.0.1"
 edition.workspace = true

--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "fluent-fallback"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. This crate exposes
-a high-level implementation of a collection of locale bundles including
-fallback between locales.
+A high-level implementation of a collection of locale bundles including fallback between locales for Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.7.1"
 edition.workspace = true

--- a/fluent-fallback/Cargo.toml
+++ b/fluent-fallback/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "fluent-fallback"
 description = """
-High-level abstraction model for managing localization resources
-and runtime localization lifecycle.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. This crate exposes
+a high-level implementation of a collection of locale bundles including
+fallback between locales.
 """
 version = "0.7.1"
 edition.workspace = true

--- a/fluent-fallback/README.md
+++ b/fluent-fallback/README.md
@@ -8,7 +8,7 @@
 The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
 a localization system designed to unleash the entire expressive power of natural language translations.
 
-This crate exposes a high-level implementation of a collection of locale bundles including fallback between locales.
+This crate is a high-level implementation of a collection of locale bundles including fallback between locales.
 
 [Project Fluent]: https://projectfluent.org
 

--- a/fluent-fallback/README.md
+++ b/fluent-fallback/README.md
@@ -50,18 +50,6 @@ release planning and scope.
 [list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
 
 
-Local Development
------------------
-
-    cargo build
-    cargo test
-    cargo run --example simple-fallback
-
-When submitting a PR please use  [`cargo fmt`][] (nightly).
-
-[`cargo fmt`]: https://github.com/rust-lang-nursery/rustfmt
-
-
 Learn the FTL syntax
 --------------------
 

--- a/fluent-fallback/README.md
+++ b/fluent-fallback/README.md
@@ -1,24 +1,16 @@
 # Fluent Fallback
 
-The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
-a localization system designed to unleash the entire expressive power of natural language translations.
-
-This crate exposes a high-level implementation of a collection of locale bundles including fallback between locales.
-
 [![crates.io](https://img.shields.io/crates/v/fluent-fallback.svg)](https://crates.io/crates/fluent-fallback)
 [![docs.rs](https://img.shields.io/docsrs/fluent-fallback)](https://docs.rs/fluent-fallback)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
-Project Fluent keeps simple things simple and makes complex things possible.
-The syntax used for describing translations is easy to read and understand.  At
-the same time it allows, when necessary, to represent complex concepts from
-natural languages like gender, plurals, conjugations, and others.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
 
-[Documentation][]
+This crate exposes a high-level implementation of a collection of locale bundles including fallback between locales.
 
 [Project Fluent]: https://projectfluent.org
-[Documentation]: https://docs.rs/fluent/
 
 Usage
 -----
@@ -42,26 +34,6 @@ fn main() {
     assert_eq!(&value, "Hello, world!");
 }
 ```
-
-
-Learn the FTL syntax
---------------------
-
-FTL is a localization file format used for describing translation resources.
-FTL stands for _Fluent Translation List_.
-
-FTL is designed to be simple to read, but at the same time allows to represent
-complex concepts from natural languages like gender, plurals, conjugations, and
-others.
-
-    hello-user = Hello, { $username }!
-
-[Read the Fluent Syntax Guide][] in order to learn more about the syntax.  If
-you're a tool author you may be interested in the formal [EBNF grammar][].
-
-[Read the Fluent Syntax Guide]: http://projectfluent.org/fluent/guide/
-[EBNF grammar]: https://github.com/projectfluent/fluent/tree/master/spec
-
 
 Get Involved
 ------------

--- a/fluent-fallback/README.md
+++ b/fluent-fallback/README.md
@@ -40,16 +40,6 @@ fn main() {
 ```
 
 
-Status
-------
-
-The implementation is in its early stages and supports only some of the Project
-Fluent's spec.  Consult the [list of milestones][] for more information about
-release planning and scope.
-
-[list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
-
-
 Learn the FTL syntax
 --------------------
 

--- a/fluent-fallback/README.md
+++ b/fluent-fallback/README.md
@@ -1,12 +1,9 @@
-# Fluent
+# Fluent Fallback
 
-`fluent-fallback` is a Rust implementation of the [Project Fluent][] higher level API.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
 
-The `Localization` struct encapsulates a persistent localization context providing
-language fallbacking. The instance remains available throughout the whole life cycle of
-the corresponding UI, reacting to events such as locale changes, resource updates etc.
-
-The API can be used directly, or can serve as an example of state manager for `fluent-bundle` and `fluent-resmgr`.
+This crate exposes a high-level implementation of a collection of locale bundles including fallback between locales.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-fallback.svg)](https://crates.io/crates/fluent-fallback)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
@@ -19,11 +16,17 @@ natural languages like gender, plurals, conjugations, and others.
 
 [Documentation][]
 
-[Project Fluent]: http://projectfluent.org
+[Project Fluent]: https://projectfluent.org
 [Documentation]: https://docs.rs/fluent/
 
 Usage
 -----
+
+The `Localization` struct encapsulates a persistent localization context providing language fallbacking.
+The instance remains available throughout the whole life cycle of the corresponding UI,
+reacting to events such as locale changes, resource updates etc.
+
+The API can be used directly, or can serve as an example of state manager for `fluent-bundle` and `fluent-resmgr`.
 
 ```rust
 use fluent_fallback::Localization;

--- a/fluent-fallback/README.md
+++ b/fluent-fallback/README.md
@@ -6,6 +6,7 @@ a localization system designed to unleash the entire expressive power of natural
 This crate exposes a high-level implementation of a collection of locale bundles including fallback between locales.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-fallback.svg)](https://crates.io/crates/fluent-fallback)
+[![docs.rs](https://img.shields.io/docsrs/fluent-fallback)](https://docs.rs/fluent-fallback)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 

--- a/fluent-pseudo/Cargo.toml
+++ b/fluent-pseudo/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "fluent-pseudo"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. This crate provides
-a pseudolocalization and transformation API.
+A pseudolocalization and transformation API for Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.3.2"
 edition.workspace = true

--- a/fluent-pseudo/Cargo.toml
+++ b/fluent-pseudo/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "fluent-pseudo"
 description = """
-Pseudolocalization transformation API for use with Project Fluent API.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. This crate provides
+a pseudolocalization and transformation API.
 """
 version = "0.3.2"
 edition.workspace = true

--- a/fluent-pseudo/README.md
+++ b/fluent-pseudo/README.md
@@ -1,14 +1,14 @@
 # Fluent Pseudo
 
-The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
-a localization system designed to unleash the entire expressive power of natural language translations.
-
-This crate provides a pseudolocalization and transformation API.
-
 [![crates.io](https://img.shields.io/crates/v/fluent-pseudo.svg)](https://crates.io/crates/fluent-pseudo)
 [![docs.rs](https://img.shields.io/docsrs/fluent-pseudo)](https://docs.rs/fluent-pseudo)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
+
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate provides a pseudolocalization and transformation API.
 
 [Project Fluent]: https://projectfluent.org
 

--- a/fluent-pseudo/README.md
+++ b/fluent-pseudo/README.md
@@ -1,12 +1,15 @@
-# Fluent
+# Fluent Pseudo
 
-`fluent-pseudo` is a Rust implementation of the pseudolocalization API for [Project Fluent](https://projectfluent.org/), a localization
-framework designed to unleash the entire expressive power of natural language
-translations.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate provides a pseudolocalization and transformation API.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-pseudo.svg)](https://crates.io/crates/fluent-pseudo)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
+
+[Project Fluent]: https://projectfluent.org
 
 Usage
 -----

--- a/fluent-pseudo/README.md
+++ b/fluent-pseudo/README.md
@@ -6,6 +6,7 @@ a localization system designed to unleash the entire expressive power of natural
 This crate provides a pseudolocalization and transformation API.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-pseudo.svg)](https://crates.io/crates/fluent-pseudo)
+[![docs.rs](https://img.shields.io/docsrs/fluent-pseudo)](https://docs.rs/fluent-pseudo)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 

--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "fluent-resmgr"
 description = """
-Resource manager for Fluent localization resources.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. This crate provides
+a standalone solution for managing localization resource files and returning
+locale bundles.
 """
 version = "0.0.7"
 edition.workspace = true

--- a/fluent-resmgr/Cargo.toml
+++ b/fluent-resmgr/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "fluent-resmgr"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. This crate provides
-a standalone solution for managing localization resource files and returning
-locale bundles.
+A standalone solution for managing resource files and returning locale bundles for Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.0.7"
 edition.workspace = true

--- a/fluent-resmgr/README.md
+++ b/fluent-resmgr/README.md
@@ -1,9 +1,9 @@
 # Fluent Resource Manager
 
-`fluent-resmgr` is an implementation of resource manager for [Project Fluent][].
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
 
-Resource Manager provides a standalone solution for managing localization resources which
-can be used by `fluent-fallback` or other higher level bindings.
+This crate provides a standalone solution for managing localization resource files and returning locale bundles.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-resmgr.svg)](https://crates.io/crates/fluent-resmgr)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
@@ -16,7 +16,7 @@ natural languages like gender, plurals, conjugations, and others.
 
 [Documentation][]
 
-[Project Fluent]: http://projectfluent.org
+[Project Fluent]: https://projectfluent.org
 [Documentation]: https://docs.rs/fluent/
 
 Usage

--- a/fluent-resmgr/README.md
+++ b/fluent-resmgr/README.md
@@ -47,18 +47,6 @@ release planning and scope.
 [list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
 
 
-Local Development
------------------
-
-    cargo build
-    cargo test
-    cargo run --example simple
-
-When submitting a PR please use  [`cargo fmt`][] (nightly).
-
-[`cargo fmt`]: https://github.com/rust-lang-nursery/rustfmt
-
-
 Learn the FTL syntax
 --------------------
 

--- a/fluent-resmgr/README.md
+++ b/fluent-resmgr/README.md
@@ -8,7 +8,7 @@
 The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
 a localization system designed to unleash the entire expressive power of natural language translations.
 
-This crate provides a standalone solution for managing localization resource files and returning locale bundles.
+This crate is a standalone solution for managing resource files and returning locale bundles.
 
 [Project Fluent]: https://projectfluent.org
 

--- a/fluent-resmgr/README.md
+++ b/fluent-resmgr/README.md
@@ -37,16 +37,6 @@ fn main() {
 ```
 
 
-Status
-------
-
-The implementation is in its early stages and supports only some of the Project
-Fluent's spec.  Consult the [list of milestones][] for more information about
-release planning and scope.
-
-[list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
-
-
 Learn the FTL syntax
 --------------------
 

--- a/fluent-resmgr/README.md
+++ b/fluent-resmgr/README.md
@@ -1,24 +1,16 @@
 # Fluent Resource Manager
 
-The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
-a localization system designed to unleash the entire expressive power of natural language translations.
-
-This crate provides a standalone solution for managing localization resource files and returning locale bundles.
-
 [![crates.io](https://img.shields.io/crates/v/fluent-resmgr.svg)](https://crates.io/crates/fluent-resmgr)
 [![docs.rs](https://img.shields.io/docsrs/fluent-resmgr)](https://docs.rs/fluent-resmgr)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
-Project Fluent keeps simple things simple and makes complex things possible.
-The syntax used for describing translations is easy to read and understand.  At
-the same time it allows, when necessary, to represent complex concepts from
-natural languages like gender, plurals, conjugations, and others.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
 
-[Documentation][]
+This crate provides a standalone solution for managing localization resource files and returning locale bundles.
 
 [Project Fluent]: https://projectfluent.org
-[Documentation]: https://docs.rs/fluent/
 
 Usage
 -----
@@ -36,26 +28,6 @@ fn main() {
     assert_eq!(&value, "Hello, world!");
 }
 ```
-
-
-Learn the FTL syntax
---------------------
-
-FTL is a localization file format used for describing translation resources.
-FTL stands for _Fluent Translation List_.
-
-FTL is designed to be simple to read, but at the same time allows to represent
-complex concepts from natural languages like gender, plurals, conjugations, and
-others.
-
-    hello-user = Hello, { $username }!
-
-[Read the Fluent Syntax Guide][] in order to learn more about the syntax.  If
-you're a tool author you may be interested in the formal [EBNF grammar][].
-
-[Read the Fluent Syntax Guide]: http://projectfluent.org/fluent/guide/
-[EBNF grammar]: https://github.com/projectfluent/fluent/tree/master/spec
-
 
 Get Involved
 ------------

--- a/fluent-resmgr/README.md
+++ b/fluent-resmgr/README.md
@@ -6,6 +6,7 @@ a localization system designed to unleash the entire expressive power of natural
 This crate provides a standalone solution for managing localization resource files and returning locale bundles.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-resmgr.svg)](https://crates.io/crates/fluent-resmgr)
+[![docs.rs](https://img.shields.io/docsrs/fluent-resmgr)](https://docs.rs/fluent-resmgr)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 

--- a/fluent-syntax/Cargo.toml
+++ b/fluent-syntax/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "fluent-syntax"
 description = """
-Parser/Serializer tools for Fluent Syntax.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. This crate exposes the low
+level parser, AST, and serializer APIs for the Fluent Syntax.
 """
 version = "0.11.1"
 edition.workspace = true

--- a/fluent-syntax/Cargo.toml
+++ b/fluent-syntax/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "fluent-syntax"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. This crate exposes the low
-level parser, AST, and serializer APIs for the Fluent Syntax.
+A low-level parser, AST, and serializer API for the syntax used by Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.11.1"
 edition.workspace = true

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -6,6 +6,7 @@ a localization system designed to unleash the entire expressive power of natural
 This crate exposes the low level parser, AST, and serializer APIs for the Fluent Syntax.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-syntax.svg)](https://crates.io/crates/fluent-syntax)
+[![docs.rs](https://img.shields.io/docsrs/fluent-syntax)](https://docs.rs/fluent-syntax)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -8,7 +8,7 @@
 The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
 a localization system designed to unleash the entire expressive power of natural language translations.
 
-This crate exposes the low level parser, AST, and serializer APIs for the Fluent Syntax.
+This crate is a low-level parser, AST, and serializer API for the Fluent Syntax.
 
 [Project Fluent]: https://projectfluent.org
 

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -7,11 +7,6 @@ framework designed to unleash the entire expressive power of natural language tr
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
-Status
-------
-
-The crate currently provides just a parser, which is tracking Fluent Syntax on its way to 1.0.
-
 
 Learn the FTL syntax
 --------------------

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -1,12 +1,15 @@
 # Fluent Syntax
 
-`fluent-syntax` is a parser/serializer API for the Fluent Syntax, part of the [Project Fluent](https://projectfluent.org/), a localization
-framework designed to unleash the entire expressive power of natural language translations.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate exposes the low level parser, AST, and serializer APIs for the Fluent Syntax.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-syntax.svg)](https://crates.io/crates/fluent-syntax)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
+[Project Fluent]: https://projectfluent.org
 
 Learn the FTL syntax
 --------------------

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -1,35 +1,16 @@
 # Fluent Syntax
 
-The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
-a localization system designed to unleash the entire expressive power of natural language translations.
-
-This crate exposes the low level parser, AST, and serializer APIs for the Fluent Syntax.
-
 [![crates.io](https://img.shields.io/crates/v/fluent-syntax.svg)](https://crates.io/crates/fluent-syntax)
 [![docs.rs](https://img.shields.io/docsrs/fluent-syntax)](https://docs.rs/fluent-syntax)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate exposes the low level parser, AST, and serializer APIs for the Fluent Syntax.
+
 [Project Fluent]: https://projectfluent.org
-
-Learn the FTL syntax
---------------------
-
-FTL is a localization file format used for describing translation resources.
-FTL stands for _Fluent Translation List_.
-
-FTL is designed to be simple to read, but at the same time allows to represent
-complex concepts from natural languages like gender, plurals, conjugations, and
-others.
-
-    hello-user = Hello, { $username }!
-
-[Read the Fluent Syntax Guide][] in order to learn more about the syntax.  If
-you're a tool author you may be interested in the formal [EBNF grammar][].
-
-[Read the Fluent Syntax Guide]: http://projectfluent.org/fluent/guide/
-[EBNF grammar]: https://github.com/projectfluent/fluent/tree/master/spec
-
 
 Get Involved
 ------------

--- a/fluent-syntax/README.md
+++ b/fluent-syntax/README.md
@@ -12,17 +12,6 @@ Status
 
 The crate currently provides just a parser, which is tracking Fluent Syntax on its way to 1.0.
 
-Local Development
------------------
-
-    cargo build
-    cargo test
-    cargo bench
-
-When submitting a PR please use  [`cargo fmt`][] (nightly).
-
-[`cargo fmt`]: https://github.com/rust-lang-nursery/rustfmt
-
 
 Learn the FTL syntax
 --------------------

--- a/fluent-testing/Cargo.toml
+++ b/fluent-testing/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "fluent-testing"
 description = """
-A collection of mock scenarios for testing fluent-rs components.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. A collection of mock
+scenarios for testing fluent-rs components.
 """
 version = "0.0.4"
 edition.workspace = true

--- a/fluent-testing/Cargo.toml
+++ b/fluent-testing/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "fluent-testing"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. A collection of mock
-scenarios for testing fluent-rs components.
+A collection of mock scenarios for testing components of Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.0.4"
 edition.workspace = true

--- a/fluent-testing/README.md
+++ b/fluent-testing/README.md
@@ -6,6 +6,7 @@ a localization system designed to unleash the entire expressive power of natural
 This crate is a collection of mock scenarios for testing fluent-rs components.
 
 [![crates.io](https://img.shields.io/crates/v/fluent-bundle.svg)](https://crates.io/crates/fluent-bundle)
+[![docs.rs](https://img.shields.io/docsrs/fluent-testing)](https://docs.rs/fluent-testing)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 

--- a/fluent-testing/README.md
+++ b/fluent-testing/README.md
@@ -12,14 +12,6 @@ natural languages like gender, plurals, conjugations, and others.
 [Project Fluent]: https://projectfluent.org
 [Documentation]: https://docs.rs/fluent/
 
-Status
-------
-
-The implementation is in its early stages and supports only some of the Project
-Fluent's spec.  Consult the [list of milestones][] for more information about
-release planning and scope.
-
-[list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
 
 Learn the FTL syntax
 --------------------

--- a/fluent-testing/README.md
+++ b/fluent-testing/README.md
@@ -1,17 +1,20 @@
-# Fluent
+# Fluent Testing
 
-`fluent-testing` is a collection of mock scenarios for testing fluent-rs components.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate is a collection of mock scenarios for testing fluent-rs components.
+
+[![crates.io](https://img.shields.io/crates/v/fluent-bundle.svg)](https://crates.io/crates/fluent-bundle)
+[![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
 Project Fluent keeps simple things simple and makes complex things possible.
 The syntax used for describing translations is easy to read and understand.  At
 the same time it allows, when necessary, to represent complex concepts from
 natural languages like gender, plurals, conjugations, and others.
 
-[Documentation][]
-
 [Project Fluent]: https://projectfluent.org
-[Documentation]: https://docs.rs/fluent/
-
 
 Learn the FTL syntax
 --------------------

--- a/fluent-testing/README.md
+++ b/fluent-testing/README.md
@@ -1,40 +1,16 @@
 # Fluent Testing
 
-The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
-a localization system designed to unleash the entire expressive power of natural language translations.
-
-This crate is a collection of mock scenarios for testing fluent-rs components.
-
 [![crates.io](https://img.shields.io/crates/v/fluent-bundle.svg)](https://crates.io/crates/fluent-bundle)
 [![docs.rs](https://img.shields.io/docsrs/fluent-testing)](https://docs.rs/fluent-testing)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
-Project Fluent keeps simple things simple and makes complex things possible.
-The syntax used for describing translations is easy to read and understand.  At
-the same time it allows, when necessary, to represent complex concepts from
-natural languages like gender, plurals, conjugations, and others.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate is a collection of mock scenarios for testing fluent-rs components.
 
 [Project Fluent]: https://projectfluent.org
-
-Learn the FTL syntax
---------------------
-
-FTL is a localization file format used for describing translation resources.
-FTL stands for _Fluent Translation List_.
-
-FTL is designed to be simple to read, but at the same time allows to represent
-complex concepts from natural languages like gender, plurals, conjugations, and
-others.
-
-    hello-user = Hello, { $username }!
-
-[Read the Fluent Syntax Guide][] in order to learn more about the syntax.  If
-you're a tool author you may be interested in the formal [EBNF grammar][].
-
-[Read the Fluent Syntax Guide]: https://projectfluent.org/fluent/guide/
-[EBNF grammar]: https://github.com/projectfluent/fluent/tree/master/spec
-
 
 Get Involved
 ------------

--- a/fluent-testing/README.md
+++ b/fluent-testing/README.md
@@ -21,19 +21,6 @@ release planning and scope.
 
 [list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
 
-
-Local Development
------------------
-
-    cargo build
-    cargo test
-    cargo run --example simple-fallback
-
-When submitting a PR please use  [`cargo fmt`][] (nightly).
-
-[`cargo fmt`]: https://github.com/rust-lang-nursery/rustfmt
-
-
 Learn the FTL syntax
 --------------------
 

--- a/fluent/Cargo.toml
+++ b/fluent/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "fluent"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. This umbrella crate
-exposes the combined features of other fluent-rs crates with additional
-convenience macros.
+An umbrella crate exposing the combined features of fluent-rs crates with additional convenience macros for Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.16.1"
 edition.workspace = true

--- a/fluent/Cargo.toml
+++ b/fluent/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "fluent"
 description = """
-A localization system designed to unleash the entire expressive power of
-natural language translations.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. This umbrella crate
+exposes the combined features of other fluent-rs crates with additional
+convenience macros.
 """
 version = "0.16.1"
 edition.workspace = true

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -1,8 +1,9 @@
 # Fluent
 
-`fluent-rs` is a Rust implementation of [Project Fluent][], a localization
-framework designed to unleash the entire expressive power of natural language
-translations.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate is an umbrella that exposes the combined features of other `fluent-rs` crates with additional convenience macros.
 
 [![crates.io](https://img.shields.io/crates/v/fluent.svg)](https://crates.io/crates/fluent)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
@@ -15,7 +16,7 @@ natural languages like gender, plurals, conjugations, and others.
 
 [Documentation][]
 
-[Project Fluent]: http://projectfluent.org
+[Project Fluent]: https://projectfluent.org
 [Documentation]: https://docs.rs/fluent/
 
 Usage

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -47,14 +47,6 @@ fn main() {
 }
 ```
 
-
-Status
-------
-
-The implementation is in pre-1.0 mode and supports Fluent Syntax 1.0, and
-Fluent API 0.14..  Consult the [list of milestones][] for more information about
-release planning and scope.
-
 `FluentBundle`, which is the main struct at the moment, is intended to remain
 a low level API.
 There is a number of higher level APIs like [fluent-resmgr][] and
@@ -63,7 +55,6 @@ for bindings and direct usage.
 Those higher level APIs are not mature yet enough to be included in this package,
 but will get added once they are.
 
-[list of milestones]: https://github.com/projectfluent/fluent-rs/milestones
 [fluent-resmgr]: https://crates.io/crates/fluent-resmgr
 [fluent-fallback]: https://crates.io/crates/fluent-fallback
 

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -90,7 +90,9 @@ FTL is designed to be simple to read, but at the same time allows to represent
 complex concepts from natural languages like gender, plurals, conjugations, and
 others.
 
-    hello-user = Hello, { $username }!
+```fluent
+hello-user = Hello, { $username }!
+```
 
 [Read the Fluent Syntax Guide][] in order to learn more about the syntax.  If
 you're a tool author you may be interested in the formal [EBNF grammar][].

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -8,7 +8,7 @@
 The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
 a localization system designed to unleash the entire expressive power of natural language translations.
 
-This crate is an umbrella that exposes the combined features of other `fluent-rs` crates with additional convenience macros.
+This is an umbrella crate exposing the combined features of `fluent-rs` crates with additional convenience macros.
 
 [Project Fluent]: https://projectfluent.org
 

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -1,24 +1,16 @@
 # Fluent
 
-The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
-a localization system designed to unleash the entire expressive power of natural language translations.
-
-This crate is an umbrella that exposes the combined features of other `fluent-rs` crates with additional convenience macros.
-
 [![crates.io](https://img.shields.io/crates/v/fluent.svg)](https://crates.io/crates/fluent)
 [![docs.rs](https://img.shields.io/docsrs/fluent)](https://docs.rs/fluent)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 
-Project Fluent keeps simple things simple and makes complex things possible.
-The syntax used for describing translations is easy to read and understand.  At
-the same time it allows, when necessary, to represent complex concepts from
-natural languages like gender, plurals, conjugations, and others.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
 
-[Documentation][]
+This crate is an umbrella that exposes the combined features of other `fluent-rs` crates with additional convenience macros.
 
 [Project Fluent]: https://projectfluent.org
-[Documentation]: https://docs.rs/fluent/
 
 Usage
 -----

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -67,18 +67,6 @@ but will get added once they are.
 [fluent-resmgr]: https://crates.io/crates/fluent-resmgr
 [fluent-fallback]: https://crates.io/crates/fluent-fallback
 
-Local Development
------------------
-
-    cargo build
-    cargo test
-    cargo bench
-    cargo run --example simple-app
-
-When submitting a PR please use  [`cargo fmt`][] (nightly).
-
-[`cargo fmt`]: https://github.com/rust-lang-nursery/rustfmt
-
 
 Learn the FTL syntax
 --------------------

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -6,6 +6,7 @@ a localization system designed to unleash the entire expressive power of natural
 This crate is an umbrella that exposes the combined features of other `fluent-rs` crates with additional convenience macros.
 
 [![crates.io](https://img.shields.io/crates/v/fluent.svg)](https://crates.io/crates/fluent)
+[![docs.rs](https://img.shields.io/docsrs/fluent)](https://docs.rs/fluent)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 

--- a/intl-memoizer/Cargo.toml
+++ b/intl-memoizer/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "intl-memoizer"
 description = """
-Project Fluent is a localization system designed to unleash the entire
-expressive power of natural language translations. This crate provides
-a memoizer specifically tailored for storing lazy-initialized intl formatters.
+A memoizer specifically tailored for storing lazy-initialized intl formatters for Project Fluent,
+a localization system designed to unleash the entire expressive power of natural language translations.
 """
 version = "0.5.2"
 edition.workspace = true

--- a/intl-memoizer/Cargo.toml
+++ b/intl-memoizer/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "intl-memoizer"
 description = """
-A memoizer specifically tailored for storing lazy-initialized
-intl formatters.
+Project Fluent is a localization system designed to unleash the entire
+expressive power of natural language translations. This crate provides
+a memoizer specifically tailored for storing lazy-initialized intl formatters.
 """
 version = "0.5.2"
 edition.workspace = true

--- a/intl-memoizer/README.md
+++ b/intl-memoizer/README.md
@@ -1,14 +1,14 @@
 # IntlMemoizer
 
-The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
-a localization system designed to unleash the entire expressive power of natural language translations.
-
-This crate provides a memoizer specifically tailored for storing lazy-initialized intl formatters.
-
 [![crates.io](https://img.shields.io/crates/v/intl-memoizer.svg)](https://crates.io/crates/intl-memoizer)
 [![docs.rs](https://img.shields.io/docsrs/intl-memoizer)](https://docs.rs/intl-memoizer)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
+
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate provides a memoizer specifically tailored for storing lazy-initialized intl formatters.
 
 [Project Fluent]: https://projectfluent.org
 

--- a/intl-memoizer/README.md
+++ b/intl-memoizer/README.md
@@ -8,7 +8,7 @@
 The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
 a localization system designed to unleash the entire expressive power of natural language translations.
 
-This crate provides a memoizer specifically tailored for storing lazy-initialized intl formatters.
+This crate is a memoizer specifically tailored for storing lazy-initialized intl formatters.
 
 [Project Fluent]: https://projectfluent.org
 

--- a/intl-memoizer/README.md
+++ b/intl-memoizer/README.md
@@ -1,7 +1,18 @@
 # IntlMemoizer
 
-`intl-memoizer` is a crate designed to handle lazy-initialized references
-to intl formatters.
+The `fluent-rs` workspace is a collection of Rust crates implementing [Project Fluent][],
+a localization system designed to unleash the entire expressive power of natural language translations.
+
+This crate provides a memoizer specifically tailored for storing lazy-initialized intl formatters.
+
+[![crates.io](https://img.shields.io/crates/v/intl-memoizer.svg)](https://crates.io/crates/intl-memoizer)
+[![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
+
+[Project Fluent]: https://projectfluent.org
+
+Usage
+-----
 
 The assumption is that allocating a new formatter instance is costly, and such
 instance is read-only during its life time, with constructor being expensive, and
@@ -9,9 +20,6 @@ instance is read-only during its life time, with constructor being expensive, an
 
 In result it pays off to use a singleton to manage memoization of all instances of intl
 APIs such as `PluralRules`, `DateTimeFormat` etc. between all `FluentBundle` instances.
-
-Usage
------
 
 The following is a high-level example of how this works, for running examples see
 the [docs](https://docs.rs/intl-memoizer/)

--- a/intl-memoizer/README.md
+++ b/intl-memoizer/README.md
@@ -6,6 +6,7 @@ a localization system designed to unleash the entire expressive power of natural
 This crate provides a memoizer specifically tailored for storing lazy-initialized intl formatters.
 
 [![crates.io](https://img.shields.io/crates/v/intl-memoizer.svg)](https://crates.io/crates/intl-memoizer)
+[![docs.rs](https://img.shields.io/docsrs/intl-memoizer)](https://docs.rs/intl-memoizer)
 [![Build](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml/badge.svg)](https://github.com/projectfluent/fluent-rs/actions/workflows/test.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/projectfluent/fluent-rs/badge.svg?branch=main)](https://coveralls.io/github/projectfluent/fluent-rs?branch=main)
 

--- a/intl-memoizer/README.md
+++ b/intl-memoizer/README.md
@@ -8,7 +8,7 @@ instance is read-only during its life time, with constructor being expensive, an
 `format`/`select` calls being cheap.
 
 In result it pays off to use a singleton to manage memoization of all instances of intl
-APIs such as `PluralRules`, DateTimeFormat` etc. between all `FluentBundle` instances.
+APIs such as `PluralRules`, `DateTimeFormat` etc. between all `FluentBundle` instances.
 
 Usage
 -----


### PR DESCRIPTION
One of the first things that bothered me about the Fluent project was how confusing it was to figure out what crates to even start with. A major factor in that is that all the README's for the crates in this project have a bunch of generic content and it isn't clear which bits are crate-specific.

The goal with this PR will be to sort out what introductory "Project Fluent" docs should go everywhere, vs. how each crate is described, vs. how all the other crates are cross-linked.
