### PR TITLE
chore(clippy): Fix `doc_lazy_continuation` lint

### DIFF
--- a/fluent-syntax/src/parser/mod.rs
+++ b/fluent-syntax/src/parser/mod.rs
@@ -3,7 +3,7 @@
 //! FTL resources can be parsed using one of two methods:
 //! * [`parse`] - parses an input into a complete Abstract Syntax Tree representation with all source information preserved.
 //! * [`parse_runtime`] - parses an input into a runtime optimized Abstract Syntax Tree
-//! representation with comments stripped.
+//!   representation with comments stripped.
 //!
 //! # Example
 //!


### PR DESCRIPTION
This is newly added in nightly clippy.