### PR TITLE
Custom functions with scope access

### DIFF
--- a/fluent-bundle/src/args.rs
+++ b/fluent-bundle/src/args.rs
@@ -52,7 +52,7 @@ use crate::types::FluentValue;
 ///     "Hello, John. You have 5 messages."
 /// );
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct FluentArgs<'args>(Vec<(Cow<'args, str>, FluentValue<'args>)>);
 
 impl<'args> FluentArgs<'args> {

--- a/fluent-bundle/src/bundle.rs
+++ b/fluent-bundle/src/bundle.rs
@@ -24,6 +24,7 @@ use crate::message::FluentMessage;
 use crate::resolver::{ResolveValue, Scope, WriteValue};
 use crate::resource::FluentResource;
 use crate::types::FluentValue;
+use crate::FluentFunctionObject;
 
 /// A collection of localization messages for a single locale, which are meant
 /// to be used together in a single view, widget or any other UI abstraction.
@@ -535,6 +536,13 @@ impl<R, M> FluentBundle<R, M> {
     pub fn add_function<F>(&mut self, id: &str, func: F) -> Result<(), FluentError>
     where
         F: for<'a> Fn(&[FluentValue<'a>], &FluentArgs) -> FluentValue<'a> + Sync + Send + 'static,
+    {
+        self.add_function_with_scope(id, func)
+    }
+
+    pub fn add_function_with_scope<F>(&mut self, id: &str, func: F) -> Result<(), FluentError>
+    where
+        F: FluentFunctionObject + Sync + Send + 'static,
     {
         match self.entries.entry(id.to_owned()) {
             HashEntry::Vacant(entry) => {

--- a/fluent-bundle/src/lib.rs
+++ b/fluent-bundle/src/lib.rs
@@ -121,6 +121,7 @@ pub use args::FluentArgs;
 /// The concurrent specialization can be constructed with
 /// [`FluentBundle::new_concurrent`](crate::concurrent::FluentBundle::new_concurrent).
 pub type FluentBundle<R> = bundle::FluentBundle<R, intl_memoizer::IntlLangMemoizer>;
+pub use entry::{FluentFunctionObject, FluentFunctionScope};
 pub use errors::FluentError;
 pub use message::{FluentAttribute, FluentMessage};
 pub use resource::FluentResource;

--- a/fluent-bundle/src/resolver/inline_expression.rs
+++ b/fluent-bundle/src/resolver/inline_expression.rs
@@ -90,7 +90,11 @@ impl<'bundle> WriteValue<'bundle> for ast::InlineExpression<&'bundle str> {
                 let func = scope.bundle.get_entry_function(id.name);
 
                 if let Some(func) = func {
-                    let result = func(resolved_positional_args.as_slice(), &resolved_named_args);
+                    let result = func.call(
+                        scope,
+                        resolved_positional_args.as_slice(),
+                        &resolved_named_args,
+                    );
                     if let FluentValue::Error = result {
                         self.write_error(w)
                     } else {
@@ -185,7 +189,11 @@ impl<'bundle> ResolveValue<'bundle> for ast::InlineExpression<&'bundle str> {
                 let func = scope.bundle.get_entry_function(id.name);
 
                 if let Some(func) = func {
-                    let result = func(resolved_positional_args.as_slice(), &resolved_named_args);
+                    let result = func.call(
+                        scope,
+                        resolved_positional_args.as_slice(),
+                        &resolved_named_args,
+                    );
                     return result;
                 } else {
                     return FluentValue::Error;

--- a/fluent-bundle/src/resolver/inline_expression.rs
+++ b/fluent-bundle/src/resolver/inline_expression.rs
@@ -3,6 +3,7 @@ use super::{ResolveValue, ResolverError, WriteValue};
 
 use std::borrow::Borrow;
 use std::fmt;
+use std::ops::Deref;
 
 use fluent_syntax::ast;
 use fluent_syntax::unicode::{unescape_unicode, unescape_unicode_to_string};
@@ -157,8 +158,12 @@ impl<'bundle> ResolveValue<'bundle> for ast::InlineExpression<&'bundle str> {
         M: MemoizerKind,
     {
         match self {
-            Self::StringLiteral { value } => unescape_unicode_to_string(value).into(),
-            Self::NumberLiteral { value } => FluentValue::try_number(value),
+            Self::StringLiteral { value } => {
+                return unescape_unicode_to_string(value).into();
+            }
+            Self::NumberLiteral { value } => {
+                return FluentValue::try_number(value);
+            }
             Self::VariableReference { id } => {
                 if let Some(local_args) = &scope.local_args {
                     if let Some(arg) = local_args.get(id.name) {
@@ -171,7 +176,7 @@ impl<'bundle> ResolveValue<'bundle> for ast::InlineExpression<&'bundle str> {
                 if scope.local_args.is_none() {
                     scope.add_error(self.into());
                 }
-                FluentValue::Error
+                return FluentValue::Error;
             }
             Self::FunctionReference { id, arguments } => {
                 let (resolved_positional_args, resolved_named_args) =
@@ -181,16 +186,22 @@ impl<'bundle> ResolveValue<'bundle> for ast::InlineExpression<&'bundle str> {
 
                 if let Some(func) = func {
                     let result = func(resolved_positional_args.as_slice(), &resolved_named_args);
-                    result
+                    return result;
                 } else {
-                    FluentValue::Error
+                    return FluentValue::Error;
                 }
             }
-            _ => {
-                let mut result = String::new();
-                self.write(&mut result, scope).expect("Failed to write");
-                result.into()
+            Self::Placeable { expression } => {
+                if let ast::Expression::Inline(expression) = expression.deref() {
+                    return expression.resolve(scope);
+                }
             }
-        }
+            _ => {}
+        };
+
+        // Fallback to text serialization
+        let mut result = String::new();
+        self.write(&mut result, scope).expect("Failed to write");
+        result.into()
     }
 }

--- a/fluent-bundle/tests/function.rs
+++ b/fluent-bundle/tests/function.rs
@@ -102,3 +102,141 @@ liked-count2 = { NUMBER($num) ->
     let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
     assert_eq!("One person liked your message", &value);
 }
+
+#[test]
+fn test_extended_function() {
+    struct ManualMessageReference;
+
+    impl fluent_bundle::FluentFunctionObject for ManualMessageReference {
+        fn call<'bundle>(
+            &self,
+            scope: &mut dyn fluent_bundle::FluentFunctionScope<'bundle>,
+            positional: &[FluentValue<'bundle>],
+            named: &FluentArgs<'bundle>,
+        ) -> FluentValue<'bundle> {
+            let Some(FluentValue::String(name)) = positional.first().cloned() else {
+                return FluentValue::Error;
+            };
+
+            let Some(msg) = scope.get_message(&name) else {
+                return FluentValue::Error;
+            };
+
+            let pattern = if let Some(FluentValue::String(attribute)) = positional.get(1) {
+                let Some(pattern) = msg.get_attribute(attribute) else {
+                    return FluentValue::Error;
+                };
+                Some(pattern.value())
+            } else {
+                msg.value()
+            };
+
+            let Some(pattern) = pattern else {
+                return FluentValue::Error;
+            };
+
+            scope.format_message(pattern, Some(named.clone()))
+        }
+    }
+
+    // Create bundle
+    let ftl_string = String::from(
+        r#"
+hero-1 = Aurora
+    .gender = feminine
+
+hero-2 = Rick
+    .gender = masculine
+
+creature-horse = { $count ->
+    *[one] a horse
+    [other] { $count } horses
+}
+
+creature-rabbit = { $count ->
+    *[one] a rabbit
+    [other] { $count } rabbits
+}
+
+annotation = Beautiful! { MSGREF($creature, count: $count) }
+
+hero-owns-creature =
+    { MSGREF($hero) } arrived! 
+    { MSGREF($hero, "gender") ->
+        [feminine] She owns
+        [masculine] He owns
+        *[other] They own
+    }
+    { MSGREF($creature, count: $count) }
+
+"#,
+    );
+
+    let res = FluentResource::try_new(ftl_string).expect("Could not parse an FTL string.");
+    let mut bundle = FluentBundle::default();
+
+    bundle
+        .add_function("NUMBER", |positional, named| match positional.first() {
+            Some(FluentValue::Number(n)) => {
+                let mut num = n.clone();
+                num.options.merge(named);
+
+                FluentValue::Number(num)
+            }
+            _ => FluentValue::Error,
+        })
+        .expect("Failed to add a function.");
+
+    bundle
+        .add_function_with_scope("MSGREF", ManualMessageReference)
+        .expect("Failed to add a function");
+
+    bundle
+        .add_resource(res)
+        .expect("Failed to add FTL resources to the bundle.");
+
+    // Examples with passing message reference to a function
+    let mut args = FluentArgs::new();
+    args.set("creature", FluentValue::from("creature-horse"));
+    args.set("count", FluentValue::from(1));
+
+    let msg = bundle
+        .get_message("annotation")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!("Beautiful! \u{2068}a horse\u{2069}", &value);
+
+    let mut args = FluentArgs::new();
+    args.set("creature", FluentValue::from("creature-rabbit"));
+    args.set("count", FluentValue::from(5));
+
+    let msg = bundle
+        .get_message("annotation")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!(
+        "Beautiful! \u{2068}\u{2068}5\u{2069} rabbits\u{2069}",
+        &value
+    );
+
+    // Example with accessing message attributes
+    let mut args = FluentArgs::new();
+    args.set("hero", FluentValue::from("hero-2"));
+    args.set("creature", FluentValue::from("creature-rabbit"));
+    args.set("count", FluentValue::from(3));
+
+    let msg = bundle
+        .get_message("hero-owns-creature")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!(
+        "\u{2068}Rick\u{2069} arrived! \n\u{2068}He owns\u{2069}\n\u{2068}\u{2068}3\u{2069} rabbits\u{2069}",
+        &value
+    );
+}

--- a/fluent-bundle/tests/terms-references-with-arguments.rs
+++ b/fluent-bundle/tests/terms-references-with-arguments.rs
@@ -1,0 +1,74 @@
+use fluent_bundle::types::FluentNumber;
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
+
+#[test]
+fn test_function_resolve() {
+    // 1. Create bundle
+    let ftl_string = String::from(
+        "
+-liked-count = { $count ->
+        [0]     No likes yet.
+        [one]   One person liked your message
+       *[other] { $count } people liked your message
+}
+
+annotation = Beautiful! { -liked-count(count: $num) }
+    ",
+    );
+
+    let res = FluentResource::try_new(ftl_string).expect("Could not parse an FTL string.");
+    let mut bundle = FluentBundle::default();
+
+    bundle
+        .add_function("NUMBER", |positional, named| match positional.first() {
+            Some(FluentValue::Number(n)) => {
+                let mut num = n.clone();
+                num.options.merge(named);
+
+                FluentValue::Number(num)
+            }
+            _ => FluentValue::Error,
+        })
+        .expect("Failed to add a function.");
+
+    bundle
+        .add_resource(res)
+        .expect("Failed to add FTL resources to the bundle.");
+
+    // 1. Example with passing custom argument to term
+    let mut args = FluentArgs::new();
+    args.set("num", FluentValue::from(1));
+
+    let msg = bundle
+        .get_message("annotation")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!("Beautiful! One person liked your message", &value);
+
+    let mut args = FluentArgs::new();
+    args.set("num", FluentValue::from(5));
+
+    let msg = bundle
+        .get_message("annotation")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!(
+        "Beautiful! \u{2068}5\u{2069} people liked your message",
+        &value
+    );
+
+    let mut args = FluentArgs::new();
+    args.set("num", FluentValue::from(0));
+
+    let msg = bundle
+        .get_message("annotation")
+        .expect("Message doesn't exist.");
+    let mut errors = vec![];
+    let pattern = msg.value().expect("Message has no value.");
+    let value = bundle.format_pattern(pattern, Some(&args), &mut errors);
+    assert_eq!("Beautiful! No likes yet.", &value);
+}

--- a/fluent-bundle/tests/terms-references-with-arguments.rs
+++ b/fluent-bundle/tests/terms-references-with-arguments.rs
@@ -1,8 +1,7 @@
-use fluent_bundle::types::FluentNumber;
 use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
 
 #[test]
-fn test_function_resolve() {
+fn test_term_argument_resolve() {
     // 1. Create bundle
     let ftl_string = String::from(
         "

--- a/fluent-syntax/src/parser/expression.rs
+++ b/fluent-syntax/src/parser/expression.rs
@@ -190,7 +190,7 @@ where
                     }
                     self.ptr += 1;
                     self.skip_blank();
-                    let val = self.get_inline_expression(true)?;
+                    let val = self.get_inline_expression(false)?;
 
                     argument_names.push(id.name.clone());
                     named.push(ast::NamedArgument {


### PR DESCRIPTION
Tries to temporary solve complex translation cases mentioned in:
https://github.com/projectfluent/fluent-rs/issues/268
https://github.com/projectfluent/fluent/issues/80

1) Support functions that can access current scope, can work as Message references.
In future we could allow access in custom functions to additional information about current scope (developer arguments, local arguments, current errors)
Message references are highly needed for more complex translation cases with a lot of possible message combinations.

2) Additionally allow using expressions inside named arguments.  
(It looks like by default fluent doesn't allow it [Playground](https://projectfluent.org/play/?s=eyJtZXNzYWdlcyI6IiMgVHJ5IGVkaXRpbmcgdGhlIHRyYW5zbGF0aW9ucyBiZWxvdy5cbiMgU2V0ICR2YXJpYWJsZXMnIHZhbHVlcyBpbiB0aGUgQ29uZmlnIHRhYi5cblxuXG4tc2hhcmVkLXBob3RvcyA9XG4gICAgeyR1c2VyTmFtZX0geyRwaG90b0NvdW50IC0-XG4gICAgICAgIFtvbmVdIGFkZGVkIGEgbmV3IHBob3RvXG4gICAgICAgKltvdGhlcl0gYWRkZWQgeyRwaG90b0NvdW50fSBuZXcgcGhvdG9zXG4gICAgfSB0byB7JHVzZXJHZW5kZXIgLT5cbiAgICAgICAgW21hbGVdIGhpcyBzdHJlYW1cbiAgICAgICAgW2ZlbWFsZV0gaGVyIHN0cmVhbVxuICAgICAgICpbb3RoZXJdIHRoZWlyIHN0cmVhbVxuICAgIH0uXG4gICAgXG5mYWlsID0gMS4geyAtc2hhcmVkLXBob3Rvcyh1c2VyTmFtZTogJHVzZXJOYW1lLCB1c2VyR2VuZGVyOiAkdXNlckdlbmRlcikgfVxub2sgPSAyLiB7IC1zaGFyZWQtcGhvdG9zKHVzZXJOYW1lOiBcInRlc3RcIiwgdXNlckdlbmRlcjogXCJ0ZXN0XCIpIH1cbiIsInZhcmlhYmxlcyI6eyJ1c2VyTmFtZSI6IkFubmUiLCJ1c2VyR2VuZGVyIjoiZmVtYWxlIiwicGhvdG9Db3VudCI6M30sInNldHVwIjp7InZpc2libGUiOlsibWVzc2FnZXMiLCJvdXRwdXQiXSwibG9jYWxlIjoiZW4tVVMiLCJkaXIiOiJsdHIifX0) )
This functionality can be placed under boolean flag if we do not want to enable it by default.

See examples included in added tests.

Would like to get feedback if these changes can be upstreamed to fluent-rs.