### PR TITLE
chore(build): fluent-syntax: Use explicit features.

### DIFF
--- a/fluent-syntax/Cargo.toml
+++ b/fluent-syntax/Cargo.toml
@@ -38,7 +38,8 @@ glob = "0.3"
 
 [features]
 default = []
-json = ["serde", "serde_json"]
+serde = ["dep:serde"]
+json = ["serde", "dep:serde_json"]
 all-benchmarks = []
 
 [[bench]]


### PR DESCRIPTION
With Rust 2024 edition coming, we should prefer explicit features over implicit features. After this change, `serde_json` no longer shows up as a feature when doing a `cargo add` as the implicit feature for it is no longer present.