### PR TITLE
Remove debug print in `NUMBER` builtin function

### DIFF
--- a/fluent-bundle/src/builtins.rs
+++ b/fluent-bundle/src/builtins.rs
@@ -8,7 +8,6 @@ pub fn NUMBER<'a>(positional: &[FluentValue<'a>], named: &FluentArgs) -> FluentV
 
     let mut n = n.clone();
     n.options.merge(named);
-    println!("{named:?} => {n:?}");
 
     FluentValue::Number(n)
 }


### PR DESCRIPTION
Looks like it was forgotten by accident in https://github.com/projectfluent/fluent-rs/pull/353/files#diff-0bf32362310a2aa403a7e651a2e8fe562fb15d1301659645b933ec312d2a64f4R11 and results in A LOT of noise in logs.