### PR TITLE
Apply new clippy lint fixes

### DIFF
--- a/fluent-bundle/examples/custom_type.rs
+++ b/fluent-bundle/examples/custom_type.rs
@@ -33,7 +33,7 @@ enum DateTimeStyleValue {
 
 // This is just a helper to make it easier to convert
 // a value provided to FluentArgs into an option value.
-impl<'l> From<&FluentValue<'l>> for DateTimeStyleValue {
+impl From<&FluentValue<'_>> for DateTimeStyleValue {
     fn from(input: &FluentValue) -> Self {
         if let FluentValue::String(s) = input {
             match s.as_ref() {
@@ -73,7 +73,7 @@ impl DateTimeOptions {
     }
 }
 
-impl<'l> From<&FluentArgs<'l>> for DateTimeOptions {
+impl From<&FluentArgs<'_>> for DateTimeOptions {
     fn from(input: &FluentArgs) -> Self {
         let mut opts = Self::default();
         opts.merge(input);

--- a/fluent-bundle/examples/functions.rs
+++ b/fluent-bundle/examples/functions.rs
@@ -35,12 +35,12 @@ fn main() {
     // Test for a function that accepts named arguments
     bundle
         .add_function("BASE_OWNERSHIP", |_args, named_args| {
-            return match named_args.get("ownership") {
+            match named_args.get("ownership") {
                 Some(FluentValue::String(ref string)) => {
                     format!("All your base belong to {}", string).into()
                 }
                 _ => FluentValue::Error,
-            };
+            }
         })
         .expect("Failed to add a function to the bundle.");
 

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -84,7 +84,7 @@ pub enum FluentValue<'source> {
     Error,
 }
 
-impl<'s> PartialEq for FluentValue<'s> {
+impl PartialEq for FluentValue<'_> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (FluentValue::String(s), FluentValue::String(s2)) => s == s2,
@@ -95,7 +95,7 @@ impl<'s> PartialEq for FluentValue<'s> {
     }
 }
 
-impl<'s> Clone for FluentValue<'s> {
+impl Clone for FluentValue<'_> {
     fn clone(&self) -> Self {
         match self {
             FluentValue::String(s) => FluentValue::String(s.clone()),
@@ -291,7 +291,7 @@ impl<'source> FluentValue<'source> {
     }
 }
 
-impl<'source> From<String> for FluentValue<'source> {
+impl From<String> for FluentValue<'_> {
     fn from(s: String) -> Self {
         FluentValue::String(s.into())
     }

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -60,9 +60,7 @@ pub trait AnyEq: Any + 'static {
 
 impl<T: Any + PartialEq> AnyEq for T {
     fn equals(&self, other: &dyn Any) -> bool {
-        other
-            .downcast_ref::<Self>()
-            .map_or(false, |that| self == that)
+        other.downcast_ref::<Self>() == Some(self)
     }
     fn as_any(&self) -> &dyn Any {
         self

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -150,11 +150,7 @@ impl FluentNumber {
         if let Some(minfd) = self.options.minimum_fraction_digits {
             if let Some(pos) = val.find('.') {
                 let frac_num = val.len() - pos - 1;
-                let missing = if frac_num > minfd {
-                    0
-                } else {
-                    minfd - frac_num
-                };
+                let missing = minfd.saturating_sub(frac_num);
                 val = format!("{}{}", val, "0".repeat(missing));
             } else {
                 val = format!("{}.{}", val, "0".repeat(minfd));

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -175,7 +175,7 @@ impl FromStr for FluentNumber {
     }
 }
 
-impl<'l> From<FluentNumber> for FluentValue<'l> {
+impl From<FluentNumber> for FluentValue<'_> {
     fn from(input: FluentNumber) -> Self {
         FluentValue::Number(input)
     }

--- a/fluent-bundle/tests/custom_types.rs
+++ b/fluent-bundle/tests/custom_types.rs
@@ -57,7 +57,7 @@ fn fluent_date_time_builtin() {
         None,
     }
 
-    impl<'l> From<&FluentValue<'l>> for DateTimeStyleValue {
+    impl From<&FluentValue<'_>> for DateTimeStyleValue {
         fn from(input: &FluentValue) -> Self {
             if let FluentValue::String(s) = input {
                 match s.as_ref() {
@@ -91,7 +91,7 @@ fn fluent_date_time_builtin() {
         }
     }
 
-    impl<'l> From<&FluentArgs<'l>> for DateTimeOptions {
+    impl From<&FluentArgs<'_>> for DateTimeOptions {
         fn from(input: &FluentArgs) -> Self {
             let mut opts = Self::default();
             opts.merge(input);

--- a/fluent-syntax/src/parser/core.rs
+++ b/fluent-syntax/src/parser/core.rs
@@ -18,7 +18,7 @@ where
     S: Slice<'s>,
 {
     pub fn new(source: S) -> Self {
-        let length = source.as_ref().as_bytes().len();
+        let length = source.as_ref().len();
         Self {
             source,
             ptr: 0,

--- a/fluent-syntax/src/parser/slice.rs
+++ b/fluent-syntax/src/parser/slice.rs
@@ -9,7 +9,7 @@ pub trait Slice<'s>: AsRef<str> + Clone + PartialEq {
     fn trim(&mut self);
 }
 
-impl<'s> Slice<'s> for String {
+impl Slice<'_> for String {
     fn slice(&self, range: Range<usize>) -> Self {
         self[range].to_string()
     }

--- a/fluent-syntax/tests/helper/mod.rs
+++ b/fluent-syntax/tests/helper/mod.rs
@@ -15,7 +15,7 @@ fn adapt_pattern(pattern: &mut ast::Pattern<String>, crlf: bool) {
         match element {
             ast::PatternElement::TextElement { value } => {
                 let mut start = 0;
-                let len = value.as_bytes().len();
+                let len = value.len();
                 for (i, b) in value.as_bytes().iter().enumerate() {
                     if b == &b'\n' {
                         if crlf {


### PR DESCRIPTION
The first commit here has some obvious fixes for convoluted code that has idiomatic Rust alternatives.

The second commit is for using lifetime elision instead of annotations. I understand this one is a bit more controversion and some projects have opted to ignore this lint instead. Personally I think I'm fine with it, I'd rather see annotations where they are meaningful and need to be included in reading the code to grok it, but if anybody here has issues with that I'm happy to consider ignoring these.
