### PR TITLE
Apply number formatting when using FluentNumberOptions

### DIFF
--- a/fluent-bundle/Cargo.toml
+++ b/fluent-bundle/Cargo.toml
@@ -40,6 +40,7 @@ serde = { workspace = true, features = ["derive"] }
 unic-langid = { workspace = true, features = ["macros"] }
 rand = "0.8"
 serde_yaml = "0.9"
+rstest = "0.24.0"
 
 [features]
 default = []

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -252,7 +252,8 @@ from_num!(f32 f64);
 
 #[cfg(test)]
 mod tests {
-    use crate::types::FluentValue;
+    use crate::types::{FluentNumber, FluentNumberOptions, FluentValue};
+    use rstest::*;
 
     #[test]
     fn value_from_copy_ref() {
@@ -260,5 +261,96 @@ mod tests {
         let y = &x;
         let z: FluentValue = y.into();
         assert_eq!(z, FluentValue::try_number("1"));
+    }
+
+    #[rstest]
+    #[case(10.12, 1, "10.12")]
+    #[case(10.0, 3, "10.000")]
+    #[case(10.12, 5, "10.12000")]
+    fn minimum_fraction_digits(#[case] input: f64, #[case] minfd: usize, #[case] expected: &str) {
+        let value = FluentNumber::new(
+            input,
+            FluentNumberOptions {
+                minimum_fraction_digits: Some(minfd),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(value.as_string(), expected);
+    }
+
+    #[rstest]
+    #[case(10.12, 0, "10")]
+    #[case(10.0, 3, "10.0")]
+    #[case(10.123456, 3, "10.123")]
+    fn maximum_fraction_digits(#[case] input: f64, #[case] maxfd: usize, #[case] expected: &str) {
+        let value = FluentNumber::new(
+            input,
+            FluentNumberOptions {
+                maximum_fraction_digits: Some(maxfd),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(value.as_string(), expected);
+    }
+
+    #[rstest]
+    #[case(10.12, 1, "10.12")]
+    #[case(10.0, 3, "010.0")]
+    #[case(10.12, 5, "00010.12")]
+    fn minimum_integer_digits(#[case] input: f64, #[case] minid: usize, #[case] expected: &str) {
+        let value = FluentNumber::new(
+            input,
+            FluentNumberOptions {
+                minimum_integer_digits: Some(minid),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(value.as_string(), expected);
+    }
+
+    #[rstest]
+    #[case(10.1, 2, 5, "10.10")]
+    #[case(10.1, 2, 1, "10.1")]
+    #[case(10.12345, 2, 3, "10.123")]
+    fn multiple_options_minfd_maxfd(
+        #[case] input: f64,
+        #[case] minfd: usize,
+        #[case] maxfd: usize,
+        #[case] expected: &str,
+    ) {
+        let value = FluentNumber::new(
+            input,
+            FluentNumberOptions {
+                minimum_fraction_digits: Some(minfd),
+                maximum_fraction_digits: Some(maxfd),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(value.as_string(), expected);
+    }
+
+    #[rstest]
+    #[case(10.1, 2, 1, "10.10")]
+    #[case(10.1, 2, 3, "010.10")]
+    fn multiple_options_minfd_minid(
+        #[case] input: f64,
+        #[case] minfd: usize,
+        #[case] minid: usize,
+        #[case] expected: &str,
+    ) {
+        let value = FluentNumber::new(
+            input,
+            FluentNumberOptions {
+                minimum_fraction_digits: Some(minfd),
+                maximum_fraction_digits: Some(minid),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(value.as_string(), expected);
     }
 }


### PR DESCRIPTION
This pull request aims to fill a gap found in the code regarding number formatting.

According to the code, 5 different format options are allowed regarding a number's length, considering rear and trailing zeroes when needed. These options are listed in the struct [`FluentNumberOptions`](https://github.com/projectfluent/fluent-rs/blob/f2033ce8340e09000ad9efccd6215b3fa5c23496/fluent-bundle/src/types/number.rs#L67).

However, I can't figure out what is the expected difference between `FluentNumberOptions.maximum_significant_digits` and  `FluentNumberOptions.maximum_fraction_digits`; and between `FluentNumberOptions.minimum_fraction_digits` and `FluentNumberOptions.minimum_significant_digits`. I'll consider those redundant, and I won't implement any specific formatting unless someone tells me what's the difference.

The current implementation:

https://github.com/projectfluent/fluent-rs/blob/f2033ce8340e09000ad9efccd6215b3fa5c23496/fluent-bundle/src/types/number.rs#L148C1-L165C2

Only considers the option `FluentNumberOptions.minimum_fraction_digits`, thus all the other options are simply ignored when provided. This was already reported by #368.

I'd like to work on a proposal for the implementation of such missing logic. I've added a few unit tests that show what kind of formatting shall be expected when using the options. So the idea is to implement the code that make those test to pass.

Please, let me know if I'm missing something.

_Notes for the reviewers:_ I added [Rstest](https://crates.io/crates/rstest) as a _dev-dependency_, if that is not acceptable, I'll rewrite the tests that I pushed.

Closes #368 