### PR TITLE
Use breaking version bump for fluent

### DIFF
--- a/fluent/CHANGELOG.md
+++ b/fluent/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-## fluent 0.16.2 (May 20, 2025)
+## fluent 0.17.0 (May 23, 2025)
+  - Bump version to reflect breaking changes in re-exported FluentBundle
+
+## fluent 0.16.2 (May 20, 2025) [yanked]
   - Cleanup docs
 
 ## fluent 0.16.1 (March 16, 2024)

--- a/fluent/Cargo.toml
+++ b/fluent/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 An umbrella crate exposing the combined features of fluent-rs crates with additional convenience macros for Project Fluent,
 a localization system designed to unleash the entire expressive power of natural language translations.
 """
-version = "0.16.2"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
* Closes #384
* Closes #385
* See also comments in #383.

It seems we have an issue with downstream projects using (indirectly) `fluent-bundle::*` while at the same time the upstream project is using `fluent::fluent_bundle::*`. This is kind of a weird arrangement, but given that we're exposing it it does seem like the resolver has trouble getting the right combination.

Note `cargo semver-checks` did *not* catch this, but that may be a bug.

If we yank 0.16.2 and replace it with 0.17.0 we might mitigate some of the pain downstream.

Thoughts?
