### PR TITLE
docs: Remove useless doc comment

### DIFF
--- a/fluent-bundle/examples/custom_type.rs
+++ b/fluent-bundle/examples/custom_type.rs
@@ -115,8 +115,6 @@ impl FluentType for DateTime {
     }
 }
 
-/// Formatter
-
 struct DateTimeFormatter {
     lang: LanguageIdentifier,
     options: DateTimeOptions,


### PR DESCRIPTION
This doc comment triggers the `clippy::empty_line_after_doc_comments` lint. It could be converted to a normal comment, or the newline could be deleted, but I don't think the comment provides any information not already contained in the struct name, so there is no point in keeping it.