### PR TITLE
feat: Make `fluent_syntax::parser::core::Parser` pub

### DIFF
--- a/fluent-syntax/src/parser/mod.rs
+++ b/fluent-syntax/src/parser/mod.rs
@@ -78,6 +78,7 @@ mod runtime;
 mod slice;
 
 use crate::ast;
+pub use core::Parser;
 pub use errors::{ErrorKind, ParserError};
 pub(crate) use slice::matches_fluent_ws;
 pub use slice::Slice;


### PR DESCRIPTION
This allows creating a simple FTL formatter by parsing and then immediately serializing the parsing result again.